### PR TITLE
Fix utilisation charts on Safari

### DIFF
--- a/packages/app/src/features/market-details/components/charts/market-overview/MarketOverviewChart.tsx
+++ b/packages/app/src/features/market-details/components/charts/market-overview/MarketOverviewChart.tsx
@@ -11,7 +11,7 @@ export function MarketOverviewChart({ data, children }: MarketOverviewChartProps
   return (
     <div className="flex w-[174px] items-center justify-center justify-self-center">
       <div className="absolute">{children}</div>
-      <DoughnutChart outerRadius={174} innerRadius={156} data={data} />
+      <DoughnutChart outerRadius={174} innerRadius={156} data={data} className="grow" />
     </div>
   )
 }


### PR DESCRIPTION
Turns out that on Safari `svg` element in a flex container is shrinked to minimal possible size, which was `0 0` in our case.