### PR TITLE
Add Spark airdrop info to market details

### DIFF
--- a/packages/app/src/features/market-details/components/spark-info-panel/SparkInfoPanel.stories.tsx
+++ b/packages/app/src/features/market-details/components/spark-info-panel/SparkInfoPanel.stories.tsx
@@ -1,0 +1,24 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { SparkInfoPanel } from './SparkInfoPanel'
+
+const meta: Meta<typeof SparkInfoPanel> = {
+  title: 'Features/MarketDetails/Components/SparkInfoPanel',
+  component: SparkInfoPanel,
+  args: {
+    title: <>Title</>,
+    content: (
+      <>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur non ex in nibh ullamcorper eleifend quis
+        tincidunt velit. Cras mollis tincidunt porta. Donec justo augue.{' '}
+      </>
+    ),
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof SparkInfoPanel>
+
+export const Default: Story = {
+  name: 'Default',
+}

--- a/packages/app/src/features/market-details/components/spark-info-panel/SparkInfoPanel.tsx
+++ b/packages/app/src/features/market-details/components/spark-info-panel/SparkInfoPanel.tsx
@@ -10,7 +10,7 @@ export function SparkInfoPanel({ title, content }: SparkInfoProps) {
   return (
     <div className="bg-spark/10 col-start-1 col-end-[-1] mt-6 flex items-center rounded-lg border-none py-4">
       <div className="mx-3">
-        <img src={assets.sparkIcon} alt="Spark logo" className='h-[2.75rem]' />
+        <img src={assets.sparkIcon} alt="Spark logo" className="h-[2.75rem]" />
       </div>
       <div className="content-center">
         <Typography variant="h4" className="col-span-1 mt-1 content-end">

--- a/packages/app/src/features/market-details/components/spark-info-panel/SparkInfoPanel.tsx
+++ b/packages/app/src/features/market-details/components/spark-info-panel/SparkInfoPanel.tsx
@@ -1,0 +1,25 @@
+import { assets } from '@/ui/assets'
+import { Typography } from '@/ui/atoms/typography/Typography'
+
+interface SparkInfoProps {
+  title: JSX.Element
+  content: JSX.Element
+}
+
+export function SparkInfoPanel({ title, content }: SparkInfoProps) {
+  return (
+    <div className="bg-spark/10 col-start-1 col-end-[-1] mt-6 flex items-center rounded-lg border-none py-4">
+      <div className="mx-3">
+        <img src={assets.sparkIcon} alt="Spark logo" className='h-[2.75rem]' />
+      </div>
+      <div className="content-center">
+        <Typography variant="h4" className="col-span-1 mt-1 content-end">
+          {title}
+        </Typography>
+        <Typography className="col-span-1 mt-1 content-start">
+          <p className="text-prompt-foreground text-xs">{content}</p>
+        </Typography>
+      </div>
+    </div>
+  )
+}

--- a/packages/app/src/features/market-details/components/spark-info-panel/SparkInfoPanel.tsx
+++ b/packages/app/src/features/market-details/components/spark-info-panel/SparkInfoPanel.tsx
@@ -8,17 +8,11 @@ interface SparkInfoProps {
 
 export function SparkInfoPanel({ title, content }: SparkInfoProps) {
   return (
-    <div className="bg-spark/10 col-start-1 col-end-[-1] mt-6 flex items-center rounded-lg border-none py-4">
-      <div className="mx-3">
-        <img src={assets.sparkIcon} alt="Spark logo" className="h-[2.75rem]" />
-      </div>
-      <div className="content-center">
-        <Typography variant="h4" className="col-span-1 mt-1 content-end">
-          {title}
-        </Typography>
-        <Typography className="col-span-1 mt-1 content-start">
-          <p className="text-prompt-foreground text-xs">{content}</p>
-        </Typography>
+    <div className="bg-spark/10 flex flex-row items-center gap-3.5 rounded-lg p-[15px]">
+      <img src={assets.sparkIcon} alt="Spark logo" className="h-[2.75rem]" />
+      <div className="flex flex-col gap-1">
+        <Typography variant="h4">{title}</Typography>
+        <p className="text-prompt-foreground text-xs">{content}</p>
       </div>
     </div>
   )

--- a/packages/app/src/features/market-details/components/status-panel/BorrowStatusPanel.tsx
+++ b/packages/app/src/features/market-details/components/status-panel/BorrowStatusPanel.tsx
@@ -87,16 +87,18 @@ export function BorrowStatusPanel({
           <InterestYieldChart {...chartProps} />
         </div>
         {airdropEligible && (
-          <SparkInfoPanel
-            title={<>Eligible for 24M Spark Airdrop</>}
-            content={
-              <div>
-                {airdropTokenSymbol} borrowers will be eligible for a future ⚡ SPK airdrop. Please read the details{' '}
-                <br />
-                on the <DocsLink to={links.docs.sparkAirdrop}>Spark Docs</DocsLink>.
-              </div>
-            }
-          />
+          <div className="col-span-3 mt-6 sm:mt-10">
+            <SparkInfoPanel
+              title={<>Eligible for 24M Spark Airdrop</>}
+              content={
+                <div>
+                  {airdropTokenSymbol} borrowers will be eligible for a future ⚡ SPK airdrop. Please read the details{' '}
+                  <br />
+                  on the <DocsLink to={links.docs.sparkAirdrop}>Spark Docs</DocsLink>.
+                </div>
+              }
+            />
+          </div>
         )}
       </StatusPanelGrid>
     </Panel.Wrapper>

--- a/packages/app/src/features/market-details/components/status-panel/BorrowStatusPanel.tsx
+++ b/packages/app/src/features/market-details/components/status-panel/BorrowStatusPanel.tsx
@@ -2,10 +2,14 @@ import { formatPercentage } from '@/domain/common/format'
 import { BorrowEligibilityStatus } from '@/domain/market-info/reserve-status'
 import { NormalizedUnitNumber, Percentage } from '@/domain/types/NumericValues'
 import { Token } from '@/domain/types/Token'
+import { TokenSymbol } from '@/domain/types/TokenSymbol'
+import { DocsLink } from '@/ui/atoms/docs-link/DocsLink'
 import { Panel } from '@/ui/atoms/panel/Panel'
+import { links } from '@/ui/constants/links'
 import { ApyTooltip } from '@/ui/molecules/apy-tooltip/ApyTooltip'
 
 import { InterestYieldChart, InterestYieldChartProps } from '../charts/interest-yield/InterestYieldChart'
+import { SparkInfoPanel } from '../spark-info-panel/SparkInfoPanel'
 import { EmptyStatusPanel } from './components/EmptyStatusPanel'
 import { Header } from './components/Header'
 import { InfoTile } from './components/info-tile/InfoTile'
@@ -17,12 +21,14 @@ import { TokenBadge } from './components/token-badge/TokenBadge'
 
 interface BorrowStatusPanelProps {
   status: BorrowEligibilityStatus
+  airdropEligible: boolean
   token: Token
   totalBorrowed: NormalizedUnitNumber
   borrowCap?: NormalizedUnitNumber
   reserveFactor: Percentage
   apy: Percentage
   chartProps: InterestYieldChartProps
+  airdropTokenSymbol: TokenSymbol
   showTokenBadge?: boolean
 }
 
@@ -34,6 +40,8 @@ export function BorrowStatusPanel({
   reserveFactor,
   apy,
   chartProps,
+  airdropTokenSymbol,
+  airdropEligible,
   showTokenBadge = false,
 }: BorrowStatusPanelProps) {
   if (status === 'no') {
@@ -78,6 +86,18 @@ export function BorrowStatusPanel({
         <div className="col-span-3 mt-6 sm:mt-10">
           <InterestYieldChart {...chartProps} />
         </div>
+        {airdropEligible && (
+          <SparkInfoPanel
+            title={<>Eligible for 24M Spark Airdrop</>}
+            content={
+              <div>
+                {airdropTokenSymbol} borrowers will be eligible for a future ⚡ SPK airdrop. Please read the details{' '}
+                <br />
+                on the <DocsLink to={links.docs.sparkAirdrop}>Spark Docs</DocsLink>.
+              </div>
+            }
+          />
+        )}
       </StatusPanelGrid>
     </Panel.Wrapper>
   )

--- a/packages/app/src/features/market-details/components/status-panel/EModeStatusPanel.tsx
+++ b/packages/app/src/features/market-details/components/status-panel/EModeStatusPanel.tsx
@@ -6,7 +6,7 @@ import { Percentage } from '@/domain/types/NumericValues'
 import { Token } from '@/domain/types/Token'
 import { TokenSymbol } from '@/domain/types/TokenSymbol'
 import { assets } from '@/ui/assets'
-import { Link, LinkProps } from '@/ui/atoms/link/Link'
+import { DocsLink } from '@/ui/atoms/docs-link/DocsLink'
 import { Panel } from '@/ui/atoms/panel/Panel'
 import { links } from '@/ui/constants/links'
 import { EModeBadge } from '@/ui/molecules/e-mode-badge/EModeBadge'
@@ -87,14 +87,6 @@ export function EModeStatusPanel({
         </InfoTilesGrid>
       </StatusPanelGrid>
     </Panel.Wrapper>
-  )
-}
-
-function DocsLink({ to, children, ...rest }: LinkProps) {
-  return (
-    <Link to={to} external className="text-slate-500 underline hover:text-slate-700" {...rest}>
-      {children}
-    </Link>
   )
 }
 

--- a/packages/app/src/features/market-details/components/status-panel/SupplyStatusPanel.tsx
+++ b/packages/app/src/features/market-details/components/status-panel/SupplyStatusPanel.tsx
@@ -2,9 +2,13 @@ import { formatPercentage } from '@/domain/common/format'
 import { SupplyAvailabilityStatus } from '@/domain/market-info/reserve-status'
 import { NormalizedUnitNumber, Percentage } from '@/domain/types/NumericValues'
 import { Token } from '@/domain/types/Token'
+import { TokenSymbol } from '@/domain/types/TokenSymbol'
+import { DocsLink } from '@/ui/atoms/docs-link/DocsLink'
 import { Panel } from '@/ui/atoms/panel/Panel'
+import { links } from '@/ui/constants/links'
 import { ApyTooltip } from '@/ui/molecules/apy-tooltip/ApyTooltip'
 
+import { SparkInfoPanel } from '../spark-info-panel/SparkInfoPanel'
 import { EmptyStatusPanel } from './components/EmptyStatusPanel'
 import { Header } from './components/Header'
 import { InfoTile } from './components/info-tile/InfoTile'
@@ -15,13 +19,23 @@ import { Subheader } from './components/Subheader'
 
 interface SupplyStatusPanelProps {
   status: SupplyAvailabilityStatus
+  airdropEligible: boolean
   token: Token
   totalSupplied: NormalizedUnitNumber
   supplyCap?: NormalizedUnitNumber
   apy: Percentage
+  airdropTokenSymbol: TokenSymbol
 }
 
-export function SupplyStatusPanel({ status, token, totalSupplied, supplyCap, apy }: SupplyStatusPanelProps) {
+export function SupplyStatusPanel({
+  status,
+  token,
+  totalSupplied,
+  supplyCap,
+  apy,
+  airdropEligible,
+  airdropTokenSymbol,
+}: SupplyStatusPanelProps) {
   if (status === 'no') {
     return <EmptyStatusPanel status={status} variant="supply" />
   }
@@ -56,6 +70,18 @@ export function SupplyStatusPanel({ status, token, totalSupplied, supplyCap, apy
             </InfoTile>
           )}
         </InfoTilesGrid>
+        {airdropEligible && (
+          <SparkInfoPanel
+            title={<>Eligible for 24M Spark Airdrop</>}
+            content={
+              <>
+                {airdropTokenSymbol} depositors will be eligible for a future ⚡ SPK airdrop. Please read the details{' '}
+                <br />
+                on the <DocsLink to={links.docs.sparkAirdrop}>Spark Docs</DocsLink>.
+              </>
+            }
+          />
+        )}
       </StatusPanelGrid>
     </Panel.Wrapper>
   )

--- a/packages/app/src/features/market-details/components/status-panel/SupplyStatusPanel.tsx
+++ b/packages/app/src/features/market-details/components/status-panel/SupplyStatusPanel.tsx
@@ -71,16 +71,18 @@ export function SupplyStatusPanel({
           )}
         </InfoTilesGrid>
         {airdropEligible && (
-          <SparkInfoPanel
-            title={<>Eligible for 24M Spark Airdrop</>}
-            content={
-              <>
-                {airdropTokenSymbol} depositors will be eligible for a future ⚡ SPK airdrop. Please read the details{' '}
-                <br />
-                on the <DocsLink to={links.docs.sparkAirdrop}>Spark Docs</DocsLink>.
-              </>
-            }
-          />
+          <div className="col-span-3 mt-3 sm:mt-10">
+            <SparkInfoPanel
+              title={<>Eligible for 24M Spark Airdrop</>}
+              content={
+                <>
+                  {airdropTokenSymbol} depositors will be eligible for a future ⚡ SPK airdrop. Please read the details{' '}
+                  <br />
+                  on the <DocsLink to={links.docs.sparkAirdrop}>Spark Docs</DocsLink>.
+                </>
+              }
+            />
+          </div>
         )}
       </StatusPanelGrid>
     </Panel.Wrapper>

--- a/packages/app/src/features/market-details/logic/makeDaiMarketOverview.ts
+++ b/packages/app/src/features/market-details/logic/makeDaiMarketOverview.ts
@@ -12,9 +12,9 @@ export interface MakeDaiMarketOverviewParams {
 }
 
 export function makeDaiMarketOverview({ reserve, marketInfo, D3MInfo }: MakeDaiMarketOverviewParams): MarketOverview {
-  const baseOverview = makeMarketOverview({ reserve, marketInfo })
+  const baseOverview = makeMarketOverview({ reserve, marketInfo, airdropTokenSymbol: reserve.token.symbol })
   const sDAI = marketInfo.findOneReserveByToken(marketInfo.sDAI)
-  const sDaiOverview = makeMarketOverview({ reserve: sDAI, marketInfo })
+  const sDaiOverview = makeMarketOverview({ reserve: sDAI, marketInfo, airdropTokenSymbol: marketInfo.sDAI.symbol })
   const makerDaoCapacity = NormalizedUnitNumber(D3MInfo.maxDebtCeiling.minus(D3MInfo.D3MCurrentDebtUSD))
   const marketSize = NormalizedUnitNumber(reserve.totalLiquidity.plus(makerDaoCapacity))
   const totalAvailable = NormalizedUnitNumber(marketSize.minus(reserve.totalDebt))

--- a/packages/app/src/features/market-details/logic/makeMarketOverview.ts
+++ b/packages/app/src/features/market-details/logic/makeMarketOverview.ts
@@ -1,4 +1,6 @@
+import { getAirdropsData } from '@/config/chain/utils/airdrops'
 import { MarketInfo, Reserve } from '@/domain/market-info/marketInfo'
+import { TokenSymbol } from '@/domain/types/TokenSymbol'
 
 import { MarketOverview } from '../types'
 import { getReserveEModeCategoryTokens } from './getReserveEModeCategoryTokens'
@@ -6,14 +8,21 @@ import { getReserveEModeCategoryTokens } from './getReserveEModeCategoryTokens'
 export interface MakeMarketOverviewParams {
   marketInfo: MarketInfo
   reserve: Reserve
+  airdropTokenSymbol: TokenSymbol
 }
 
-export function makeMarketOverview({ reserve, marketInfo }: MakeMarketOverviewParams): MarketOverview {
+export function makeMarketOverview({
+  reserve,
+  marketInfo,
+  airdropTokenSymbol,
+}: MakeMarketOverviewParams): MarketOverview {
   const eModeCategoryId = reserve.eModeCategory?.id
   const eModeCategoryTokens = getReserveEModeCategoryTokens(marketInfo, reserve)
+  const airdropData = getAirdropsData(marketInfo.chainId, airdropTokenSymbol)
 
   return {
     supply: {
+      airdropEligible: airdropData.deposit.length > 0,
       status: reserve.supplyAvailabilityStatus,
       totalSupplied: reserve.totalLiquidity,
       supplyCap: reserve.supplyCap,
@@ -29,6 +38,7 @@ export function makeMarketOverview({ reserve, marketInfo }: MakeMarketOverviewPa
       liquidationPenalty: reserve.liquidationBonus,
     },
     borrow: {
+      airdropEligible: airdropData.borrow.length > 0,
       status: reserve.borrowEligibilityStatus,
       totalBorrowed: reserve.totalDebt,
       borrowCap: reserve.borrowCap,

--- a/packages/app/src/features/market-details/logic/useMarketDetails.ts
+++ b/packages/app/src/features/market-details/logic/useMarketDetails.ts
@@ -6,7 +6,9 @@ import { NotFoundError } from '@/domain/errors/not-found'
 import { useMarketInfo } from '@/domain/market-info/useMarketInfo'
 import { CheckedAddress } from '@/domain/types/CheckedAddress'
 import { Token } from '@/domain/types/Token'
+import { TokenSymbol } from '@/domain/types/TokenSymbol'
 import { useWalletInfo } from '@/domain/wallet/useWalletInfo'
+import { getNativeTokenSymbolIfWrapped } from '@/utils/getDisplyTokenSymbol'
 import { raise } from '@/utils/raise'
 
 import { MarketOverview, WalletOverview } from '../types'
@@ -22,6 +24,7 @@ export interface UseMarketDetailsResult {
   marketOverview: MarketOverview
   walletOverview: WalletOverview
   chainMismatch: boolean
+  airdropTokenSymbol: TokenSymbol
 }
 
 export function useMarketDetails(): UseMarketDetailsResult {
@@ -38,6 +41,8 @@ export function useMarketDetails(): UseMarketDetailsResult {
 
   const isDaiOverview = reserve.token.symbol === marketInfo.DAI.symbol && D3MInfo
 
+  const airdropTokenSymbol = getNativeTokenSymbolIfWrapped(marketInfo.chainId, reserve.token.symbol)
+
   const marketOverview = isDaiOverview
     ? makeDaiMarketOverview({
         reserve,
@@ -47,6 +52,7 @@ export function useMarketDetails(): UseMarketDetailsResult {
     : makeMarketOverview({
         reserve,
         marketInfo,
+        airdropTokenSymbol,
       })
   const walletOverview = makeWalletOverview({
     reserve,
@@ -62,5 +68,6 @@ export function useMarketDetails(): UseMarketDetailsResult {
     marketOverview,
     walletOverview,
     chainMismatch,
+    airdropTokenSymbol,
   }
 }

--- a/packages/app/src/features/market-details/types.ts
+++ b/packages/app/src/features/market-details/types.ts
@@ -17,6 +17,7 @@ export interface SupplyReplacementInfo {
 }
 export interface MarketOverview {
   supply?: {
+    airdropEligible: boolean
     status: SupplyAvailabilityStatus
     totalSupplied: NormalizedUnitNumber
     supplyCap?: NormalizedUnitNumber
@@ -33,6 +34,7 @@ export interface MarketOverview {
     supplyReplacement?: SupplyReplacementInfo
   }
   borrow: {
+    airdropEligible: boolean
     status: BorrowEligibilityStatus
     totalBorrowed: NormalizedUnitNumber
     borrowCap?: NormalizedUnitNumber

--- a/packages/app/src/features/market-details/views/MarketDetailsView.stories.ts
+++ b/packages/app/src/features/market-details/views/MarketDetailsView.stories.ts
@@ -27,6 +27,7 @@ const args: MarketDetailsViewProps = {
   chainName: 'Ethereum Mainnet',
   chainId: 1,
   chainMismatch: false,
+  airdropTokenSymbol: tokens['rETH'].symbol,
   walletOverview: {
     guestMode: false,
     token: tokens['rETH'],
@@ -42,6 +43,7 @@ const args: MarketDetailsViewProps = {
   },
   marketOverview: {
     supply: {
+      airdropEligible: true,
       status: 'yes',
       totalSupplied: NormalizedUnitNumber(72_000),
       supplyCap: NormalizedUnitNumber(112_000),
@@ -57,6 +59,7 @@ const args: MarketDetailsViewProps = {
       liquidationPenalty: Percentage(0.05),
     },
     borrow: {
+      airdropEligible: false,
       status: 'yes',
       totalBorrowed: NormalizedUnitNumber(1244),
       apy: Percentage(0.01),

--- a/packages/app/src/features/market-details/views/components/CompactView.tsx
+++ b/packages/app/src/features/market-details/views/components/CompactView.tsx
@@ -18,6 +18,7 @@ export function CompactView({
   chainMismatch,
   marketOverview,
   walletOverview,
+  airdropTokenSymbol,
   openConnectModal,
   openDialog,
 }: MarketDetailsViewProps) {
@@ -32,11 +33,13 @@ export function CompactView({
         </TabsList>
         <TabsContent value="overview" className="flex flex-col gap-4 px-3">
           <MarketOverviewPanel token={token} {...marketOverview.summary} />
-          {marketOverview.supply && <SupplyStatusPanel token={token} {...marketOverview.supply} />}
+          {marketOverview.supply && (
+            <SupplyStatusPanel token={token} airdropTokenSymbol={airdropTokenSymbol} {...marketOverview.supply} />
+          )}
           {marketOverview.lend && <LendStatusPanel {...marketOverview.lend} />}
           <CollateralStatusPanel {...marketOverview.collateral} />
           {marketOverview.eMode && <EModeStatusPanel {...marketOverview.eMode} />}
-          <BorrowStatusPanel token={token} {...marketOverview.borrow} />
+          <BorrowStatusPanel token={token} airdropTokenSymbol={airdropTokenSymbol} {...marketOverview.borrow} />
         </TabsContent>
         <TabsContent value="actions" className="px-3">
           <MyWalletPanel

--- a/packages/app/src/features/market-details/views/components/FullView.tsx
+++ b/packages/app/src/features/market-details/views/components/FullView.tsx
@@ -18,6 +18,7 @@ export function FullView({
   walletOverview,
   openConnectModal,
   openDialog,
+  airdropTokenSymbol,
 }: MarketDetailsViewProps) {
   return (
     <div className="w-full max-w-5xl pb-8 pt-12 sm:mx-3 lg:mx-auto">
@@ -25,11 +26,13 @@ export function FullView({
       <Header token={token} chainName={chainName} chainMismatch={chainMismatch} />
       <div className="grid grid-cols-[2fr_1fr] gap-5 md:gap-10">
         <div className="flex flex-col gap-6">
-          {marketOverview.supply && <SupplyStatusPanel token={token} {...marketOverview.supply} />}
+          {marketOverview.supply && (
+            <SupplyStatusPanel token={token} airdropTokenSymbol={airdropTokenSymbol} {...marketOverview.supply} />
+          )}
           {marketOverview.lend && <LendStatusPanel {...marketOverview.lend} />}
           <CollateralStatusPanel {...marketOverview.collateral} />
           {marketOverview.eMode && <EModeStatusPanel {...marketOverview.eMode} />}
-          <BorrowStatusPanel token={token} {...marketOverview.borrow} />
+          <BorrowStatusPanel token={token} airdropTokenSymbol={airdropTokenSymbol} {...marketOverview.borrow} />
         </div>
         <div className="flex flex-col gap-6">
           <MarketOverviewPanel token={token} {...marketOverview.summary} />

--- a/packages/app/src/ui/atoms/docs-link/DocsLink.tsx
+++ b/packages/app/src/ui/atoms/docs-link/DocsLink.tsx
@@ -1,0 +1,9 @@
+import { Link, LinkProps } from '@/ui/atoms/link/Link'
+
+export function DocsLink({ to, children, ...rest }: LinkProps) {
+  return (
+    <Link to={to} external className="text-slate-500 underline hover:text-slate-700" {...rest}>
+      {children}
+    </Link>
+  )
+}

--- a/packages/app/src/utils/getDisplyTokenSymbol.ts
+++ b/packages/app/src/utils/getDisplyTokenSymbol.ts
@@ -1,0 +1,16 @@
+import { getChainConfigEntry } from '@/config/chain'
+import { TokenSymbol } from '@/domain/types/TokenSymbol'
+
+/**
+ * Returns the native token symbol if the token is wrapped.
+ * @param chainId The chain ID.
+ * @param tokenSymbol The token symbol.
+ * @returns The native token symbol if the token is wrapped.
+ */
+export function getNativeTokenSymbolIfWrapped(chainId: number, tokenSymbol: TokenSymbol): TokenSymbol {
+  const chainConfig = getChainConfigEntry(chainId)
+
+  return tokenSymbol === chainConfig.nativeAssetInfo.wrappedNativeAssetSymbol
+    ? chainConfig.nativeAssetInfo.nativeAssetSymbol
+    : tokenSymbol
+}


### PR DESCRIPTION
- Airdrop information added to market details pages
- New molecule component added for creating Spark informations
- Extracted docs link to atom component

<img width="695" alt="image" src="https://github.com/marsfoundation/spark-app/assets/15217169/7bb74f6f-bd9e-4cf8-883d-319b41267161">

<img width="679" alt="image" src="https://github.com/marsfoundation/spark-app/assets/15217169/a2fdc35a-b224-4990-a0fd-e23ddffdff1c">
