### PR TITLE
Enable waiving LiFi fees on Gnosis chain

### DIFF
--- a/packages/app/src/config/chain/index.ts
+++ b/packages/app/src/config/chain/index.ts
@@ -64,7 +64,6 @@ const chainConfig: ChainConfig = {
     savingsInfoQuery: mainnetSavingsInfoQuery,
     daiSymbol: TokenSymbol('DAI'),
     sDaiSymbol: TokenSymbol('sDAI'),
-    supportsLifiWaivedFees: true,
   },
   [gnosis.id]: {
     id: gnosis.id,
@@ -103,7 +102,6 @@ const chainConfig: ChainConfig = {
       import.meta.env.VITE_DEV_GNOSIS_SAVINGS === '1' ? gnosisSavingsInfoQuery : unsupportedSavingsInfoQuery,
     daiSymbol: TokenSymbol('XDAI'),
     sDaiSymbol: TokenSymbol('sDAI'),
-    supportsLifiWaivedFees: false,
   },
 }
 

--- a/packages/app/src/config/chain/types.ts
+++ b/packages/app/src/config/chain/types.ts
@@ -45,7 +45,6 @@ export interface ChainConfigEntry {
   savingsInfoQuery: (args: SavingsInfoQueryParams) => SavingsInfoQueryOptions
   daiSymbol: TokenSymbol
   sDaiSymbol: TokenSymbol
-  supportsLifiWaivedFees: boolean
 }
 
 export type ChainConfig = Record<SupportedChainId, ChainConfigEntry>

--- a/packages/app/src/domain/exchanges/lifi/meta/useLifiQueryMetaEvaluator.ts
+++ b/packages/app/src/domain/exchanges/lifi/meta/useLifiQueryMetaEvaluator.ts
@@ -1,4 +1,3 @@
-import { getChainConfigEntry } from '@/config/chain'
 import { useMarketInfo } from '@/domain/market-info/useMarketInfo'
 import { TokenSymbol } from '@/domain/types/TokenSymbol'
 
@@ -15,16 +14,9 @@ export function useLifiQueryMetaEvaluator(): LifiQueryMetaEvaluator {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const { marketInfo } = useMarketInfo()
 
-  const waivedTokens = (() => {
-    if (!getChainConfigEntry(marketInfo.chainId).supportsLifiWaivedFees) {
-      return {}
-    }
-    const dai = marketInfo.DAI.address
-    const sdai = marketInfo.sDAI.address
-    const usdc = marketInfo.findTokenBySymbol(TokenSymbol('USDC'))?.address
+  const dai = marketInfo.DAI.address
+  const sdai = marketInfo.sDAI.address
+  const usdc = marketInfo.findTokenBySymbol(TokenSymbol('USDC'))?.address
 
-    return { dai, sdai, usdc }
-  })()
-
-  return new RealLifiQueryMetaEvaluator(waivedTokens)
+  return new RealLifiQueryMetaEvaluator({ dai, sdai, usdc })
 }


### PR DESCRIPTION
- Removed flag `supportsLifiWaivedFees` from chain config.
- Made `useLifiQueryMetaEvaluator` hook return waived fee integrator for specified routes on Gnosis chain.