### PR TITLE
Use getLogs method instead of watching events in useWaitForGnosisTransaction

### DIFF
--- a/packages/app/src/config/wagmi/config.default.ts
+++ b/packages/app/src/config/wagmi/config.default.ts
@@ -1,5 +1,5 @@
 import { getDefaultConfig } from '@rainbow-me/rainbowkit'
-import { http, Chain, Transport, webSocket } from 'viem'
+import { http, Chain, Transport } from 'viem'
 import { gnosis, mainnet } from 'viem/chains'
 import { Config } from 'wagmi'
 
@@ -19,7 +19,7 @@ export function getConfig(sandboxNetwork?: SandboxNetwork): Config {
   const forkChain = getForkChainFromSandboxConfig(sandboxNetwork)
 
   const transports: Record<SupportedChainId, Transport> = {
-    [mainnet.id]: webSocket(`wss://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}`),
+    [mainnet.id]: http(`https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}`),
     [gnosis.id]: http('https://rpc.ankr.com/gnosis'),
   }
 

--- a/packages/app/src/domain/hooks/useWaitForTransactionReceiptGnosisSafe.test.ts
+++ b/packages/app/src/domain/hooks/useWaitForTransactionReceiptGnosisSafe.test.ts
@@ -1,0 +1,69 @@
+import { testAddresses } from '@/test/integration/constants'
+import { expectToStayUndefined } from '@/test/integration/expect'
+import { createBlockNumberCallHandler, createGetLogsHandler, handlers } from '@/test/integration/mockTransport/handlers'
+import { setupHookRenderer } from '@/test/integration/setupHookRenderer'
+import { waitFor } from '@testing-library/react'
+import { parseAbiItem } from 'viem'
+import { describe, test } from 'vitest'
+import { useWaitForTransactionReceiptGnosisSafe } from './useWaitForTransactionReceiptGnosisSafe'
+
+const hookRenderer = setupHookRenderer({
+  hook: useWaitForTransactionReceiptGnosisSafe,
+  account: testAddresses.alice,
+  handlers: [],
+  args: undefined,
+})
+
+describe(useWaitForTransactionReceiptGnosisSafe.name, () => {
+  test('waits until event is emitted', async () => {
+    const gnosisTxHash = '0xb1ec3f7f1b1d8d6b5b1f6e7a8c9c7d8e7f1b8e7c1b8f7a8e7f1b8e7a8f1b8e7c'
+    const subTxHash = '0x8e8c3f7f1b1d8d6b5b1f6e7a8c9c7d8e7f1b8e7c1b8f7a8e7f1b8e7a8f1b8e7c'
+    const initialBlockNumber = 1000n
+
+    const { handler: blockNumberHandler, incrementBlockNumber } = createBlockNumberCallHandler(initialBlockNumber)
+    const { handler: logsHandler, setEnabled: setLogsHandlerEnabled } = createGetLogsHandler({
+      address: testAddresses.alice,
+      event: parseAbiItem('event ExecutionSuccess(bytes32 txHash, uint256 payment)'),
+      args: {
+        txHash: gnosisTxHash,
+        payment: 0n,
+      },
+      blockNumber: initialBlockNumber + 2n,
+      transactionHash: gnosisTxHash,
+    })
+
+    const { result } = hookRenderer({
+      handlers: [
+        blockNumberHandler,
+        logsHandler,
+        handlers.mineTransaction({
+          txHash: gnosisTxHash,
+        }),
+      ],
+      args: {
+        hash: subTxHash,
+      },
+    })
+
+    await waitFor(() => expect(result.current).not.toBeNull())
+
+    expect(result.current.txHash).toBe(undefined)
+
+    expectToStayUndefined(() => result.current.data)
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.status).toBe('pending')
+
+    incrementBlockNumber()
+    expectToStayUndefined(() => result.current.data)
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.status).toBe('pending')
+
+    setLogsHandlerEnabled(true)
+    expectToStayUndefined(() => result.current.data)
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.status).toBe('pending')
+
+    incrementBlockNumber()
+    await waitFor(() => expect(result.current.data).toBeDefined())
+  })
+})

--- a/packages/app/src/domain/hooks/useWaitForTransactionReceiptGnosisSafe.ts
+++ b/packages/app/src/domain/hooks/useWaitForTransactionReceiptGnosisSafe.ts
@@ -1,6 +1,6 @@
 import { skipToken, useQuery } from '@tanstack/react-query'
 import invariant from 'tiny-invariant'
-import { parseAbiItem } from 'viem'
+import { Address, Client, Hash, parseAbiItem } from 'viem'
 import { getLogs, getTransactionReceipt, watchBlockNumber } from 'viem/actions'
 import {
   UseWaitForTransactionReceiptParameters,
@@ -25,60 +25,92 @@ export function useWaitForTransactionReceiptGnosisSafe(
   const chainId = useChainId()
 
   const subTxHash = args.hash
-  const enabled = Boolean(subTxHash && (args.query?.enabled ?? true))
+  const enabled = Boolean(subTxHash && address && (args.query?.enabled ?? true))
 
   return useQuery({
-    queryKey: [
-      'gnosis-safe',
-      ...waitForTransactionReceiptQueryKey({
-        ...args,
-        chainId: args.chainId ?? chainId,
-      }),
-    ],
+    queryKey: waitForTransactionReceiptGnosisSafeQueryKey(args, chainId),
     queryFn:
-      !subTxHash || !client
+      !subTxHash || !client || !address
         ? skipToken
-        : async ({ signal }) => {
-            const gnosisTxHash = await new Promise<`0x${string}`>((resolve, reject) => {
-              const unwatch = watchBlockNumber(client, {
-                emitOnBegin: true,
-                async onBlockNumber(blockNumber) {
-                  try {
-                    const logs = await getLogs(client, {
-                      address,
-                      event: executionSuccessEvent,
-                      fromBlock: blockNumber - 10n,
-                      toBlock: blockNumber,
-                    })
-
-                    for (const log of logs) {
-                      if (log.args.txHash === subTxHash) {
-                        invariant(log.transactionHash, 'Transaction hash not found')
-
-                        unwatch()
-                        resolve(log.transactionHash)
-                        return
-                      }
-                    }
-                  } catch (error) {
-                    unwatch()
-                    reject(error)
-                  }
-                },
-                async onError(error) {
-                  unwatch()
-                  reject(error)
-                },
-              })
-
-              signal?.addEventListener('abort', () => {
-                unwatch()
-              })
-            })
-
-            return getTransactionReceipt(client, { ...args, hash: gnosisTxHash })
-          },
+        : waitForTransactionReceiptGnosisSafeQueryFn({ args, subTxHash, client, address }),
     ...(args.query as any),
     enabled,
   }) as UseWaitForTransactionReceiptReturnType
+}
+
+export function waitForTransactionReceiptGnosisSafeQueryKey(
+  args: UseWaitForTransactionReceiptParameters,
+  chainId: number,
+): unknown[] {
+  return [
+    'gnosis-safe',
+    ...waitForTransactionReceiptQueryKey({
+      ...args,
+      chainId,
+    }),
+  ]
+}
+
+interface WaitForTransactionReceiptGnosisSafeQueryFnParams {
+  args: UseWaitForTransactionReceiptParameters
+  subTxHash: Hash
+  client: Client
+  address: Address
+}
+function waitForTransactionReceiptGnosisSafeQueryFn({
+  args,
+  subTxHash,
+  client,
+  address,
+}: WaitForTransactionReceiptGnosisSafeQueryFnParams) {
+  return async function queryFn({ signal }: { signal?: AbortSignal }) {
+    const gnosisTxHash = await waitForGnosisTxHash({ subTxHash, client, address, signal })
+
+    return getTransactionReceipt(client, { ...args, hash: gnosisTxHash })
+  }
+}
+
+interface WaitForGnosisTxHashParams {
+  subTxHash: Hash
+  client: Client
+  address: Address
+  signal?: AbortSignal
+}
+async function waitForGnosisTxHash({ subTxHash, client, address, signal }: WaitForGnosisTxHashParams): Promise<Hash> {
+  return new Promise<Hash>((resolve, reject) => {
+    const unwatch = watchBlockNumber(client, {
+      emitOnBegin: true,
+      async onBlockNumber(blockNumber) {
+        try {
+          const logs = await getLogs(client, {
+            address,
+            event: executionSuccessEvent,
+            fromBlock: blockNumber - 10n,
+            toBlock: blockNumber,
+          })
+
+          for (const log of logs) {
+            if (log.args.txHash === subTxHash) {
+              invariant(log.transactionHash, 'Transaction hash not found')
+
+              unwatch()
+              resolve(log.transactionHash)
+              return
+            }
+          }
+        } catch (error) {
+          unwatch()
+          reject(error)
+        }
+      },
+      async onError(error) {
+        unwatch()
+        reject(error)
+      },
+    })
+
+    signal?.addEventListener('abort', () => {
+      unwatch()
+    })
+  })
 }

--- a/packages/app/src/domain/hooks/useWaitForTransactionReceiptGnosisSafe.ts
+++ b/packages/app/src/domain/hooks/useWaitForTransactionReceiptGnosisSafe.ts
@@ -38,7 +38,7 @@ export function useWaitForTransactionReceiptGnosisSafe(
     queryFn:
       !subTxHash || !client
         ? skipToken
-        : async () => {
+        : async ({ signal }) => {
             const gnosisTxHash = await new Promise<`0x${string}`>((resolve, reject) => {
               const unwatch = watchBlockNumber(client, {
                 emitOnBegin: true,
@@ -69,6 +69,10 @@ export function useWaitForTransactionReceiptGnosisSafe(
                   unwatch()
                   reject(error)
                 },
+              })
+
+              signal?.addEventListener('abort', () => {
+                unwatch()
               })
             })
 

--- a/packages/app/src/domain/hooks/useWaitForTransactionReceiptGnosisSafe.ts
+++ b/packages/app/src/domain/hooks/useWaitForTransactionReceiptGnosisSafe.ts
@@ -28,10 +28,13 @@ export function useWaitForTransactionReceiptGnosisSafe(
   const enabled = Boolean(subTxHash && (args.query?.enabled ?? true))
 
   return useQuery({
-    queryKey: waitForTransactionReceiptQueryKey({
-      ...args,
-      chainId: args.chainId ?? chainId,
-    }),
+    queryKey: [
+      'gnosis-safe',
+      ...waitForTransactionReceiptQueryKey({
+        ...args,
+        chainId: args.chainId ?? chainId,
+      }),
+    ],
     queryFn:
       !subTxHash || !client
         ? skipToken
@@ -71,8 +74,7 @@ export function useWaitForTransactionReceiptGnosisSafe(
 
             return getTransactionReceipt(client, { ...args, hash: gnosisTxHash })
           },
-
-    enabled,
     ...(args.query as any),
+    enabled,
   }) as UseWaitForTransactionReceiptReturnType
 }

--- a/packages/app/src/domain/hooks/useWaitForTransactionReceiptUniversal.ts
+++ b/packages/app/src/domain/hooks/useWaitForTransactionReceiptUniversal.ts
@@ -14,9 +14,7 @@ import { useWalletType } from './useWalletType'
  */
 export function useWaitForTransactionReceiptUniversal(
   args: UseWaitForTransactionReceiptParameters = {},
-): UseWaitForTransactionReceiptReturnType & {
-  txHash: `0x${string}` | undefined
-} {
+): UseWaitForTransactionReceiptReturnType {
   const walletType = useWalletType()
 
   const gnosisTxReceipt = useWaitForTransactionReceiptGnosisSafe({
@@ -38,5 +36,5 @@ export function useWaitForTransactionReceiptUniversal(
     return gnosisTxReceipt
   }
 
-  return { ...receipt, txHash: args.hash }
+  return receipt
 }

--- a/packages/app/src/test/integration/expect.ts
+++ b/packages/app/src/test/integration/expect.ts
@@ -1,4 +1,5 @@
 import { waitFor } from '@testing-library/react'
+import { expect } from 'vitest'
 
 export async function expectToStayUndefined(fn: () => any): Promise<void> {
   await expect(

--- a/packages/app/src/test/integration/mockTransport/handlers.ts
+++ b/packages/app/src/test/integration/mockTransport/handlers.ts
@@ -176,7 +176,7 @@ function mineTransaction(opts: { blockNumber?: number; txHash?: string } = {}): 
       return {
         ...getEmptyTxData(),
         blockNumber: encodeRpcQuantity(blockNumber),
-        txHash,
+        transactionHash: txHash,
       }
     }
 
@@ -184,7 +184,7 @@ function mineTransaction(opts: { blockNumber?: number; txHash?: string } = {}): 
       return {
         ...getEmptyTxReceipt(),
         blockNumber: encodeRpcQuantity(blockNumber),
-        txHash,
+        transactionHash: txHash,
       }
     }
 
@@ -302,10 +302,11 @@ export interface CreateBlockNumberCallHandlerResult {
 export function createBlockNumberCallHandler(initialBlockNumber: bigint): CreateBlockNumberCallHandlerResult {
   let blockNumber = initialBlockNumber
 
-  const incrementBlockNumber = () => {
+  function incrementBlockNumber(): void {
     blockNumber++
   }
 
+  // eslint-disable-next-line func-style
   const handler: RpcHandler = (method, params) => {
     return blockNumberCall(blockNumber)(method, params)
   }
@@ -320,10 +321,11 @@ export interface CreateGetLogsHandlerResult {
 export function createGetLogsHandler(opts: GetLogsCallOptions<AbiEvent>): CreateGetLogsHandlerResult {
   let enabled = false
 
-  const setEnabled = (value: boolean) => {
+  function setEnabled(value: boolean): void {
     enabled = value
   }
 
+  // eslint-disable-next-line func-style
   const handler: RpcHandler = (method, params) => {
     if (!enabled) {
       if (method === 'eth_getLogs') {

--- a/packages/app/src/test/integration/mockTransport/handlers.ts
+++ b/packages/app/src/test/integration/mockTransport/handlers.ts
@@ -133,7 +133,7 @@ function getLogsCall<TAbiEvent extends AbiEvent>({
     }
 
     if (!isAddressEqual(params.address, address)) {
-      return []
+      return undefined
     }
 
     const topics = encodeEventTopics({
@@ -153,9 +153,9 @@ function getLogsCall<TAbiEvent extends AbiEvent>({
         data,
         blockNumber: toHex(blockNumber),
         transactionHash,
-        // the rest of the parameters are not important for us
-        transactionIndex: '0x41',
-        blockHash: '0x8e8c3f7f1b1d8d6b5b1f6e7a8c9c7d8e7f1b8e7c1b8f7a8e7f1b8e7a8f1b8e7c',
+        // the rest of the parameters is not important for us
+        transactionIndex: getEmptyTxReceipt().transactionIndex,
+        blockHash: getEmptyTxReceipt().blockHash,
         logIndex: '0x1',
         removed: false,
       },

--- a/packages/app/src/test/integration/mockTransport/handlers.ts
+++ b/packages/app/src/test/integration/mockTransport/handlers.ts
@@ -1,11 +1,18 @@
 import { isDeepStrictEqual } from 'node:util'
 import {
   Abi,
+  AbiEvent,
+  Address,
   ContractFunctionName,
+  DecodeEventLogReturnType,
   EncodeFunctionDataParameters,
   EncodeFunctionResultParameters,
+  encodeAbiParameters,
+  encodeEventTopics,
   encodeFunctionData,
   encodeFunctionResult,
+  isAddressEqual,
+  toHex,
 } from 'viem'
 
 import { TestTrigger } from '../trigger'
@@ -103,6 +110,56 @@ function contractCallError<
     }
 
     throw new MockError(opts.errorMessage)
+  }
+}
+
+export interface GetLogsCallOptions<TAbiEvent extends AbiEvent> {
+  address: Address
+  event: TAbiEvent
+  args: DecodeEventLogReturnType<[TAbiEvent]>['args']
+  blockNumber: bigint
+  transactionHash: string
+}
+function getLogsCall<TAbiEvent extends AbiEvent>({
+  address,
+  event,
+  args,
+  blockNumber,
+  transactionHash,
+}: GetLogsCallOptions<TAbiEvent>): RpcHandler {
+  return (method, [params]) => {
+    if (method !== 'eth_getLogs') {
+      return undefined
+    }
+
+    if (!isAddressEqual(params.address, address)) {
+      return []
+    }
+
+    const topics = encodeEventTopics({
+      abi: [event] as any,
+      eventName: event.name,
+    })
+
+    const data = encodeAbiParameters(
+      event.inputs,
+      event.inputs.map((input) => (args as any)[input.name!]),
+    )
+
+    return [
+      {
+        address,
+        topics,
+        data,
+        blockNumber: toHex(blockNumber),
+        transactionHash,
+        // the rest of the parameters are not important for us
+        transactionIndex: '0x41',
+        blockHash: '0x8e8c3f7f1b1d8d6b5b1f6e7a8c9c7d8e7f1b8e7c1b8f7a8e7f1b8e7a8f1b8e7c',
+        logIndex: '0x1',
+        removed: false,
+      },
+    ]
   }
 }
 
@@ -229,10 +286,55 @@ export const handlers = {
   chainIdCall,
   balanceCall,
   contractCall,
+  getLogsCall,
   contractCallError,
   mineTransaction,
   mineRevertedTransaction,
   rejectSubmittedTransaction,
   triggerHandler,
   forceCallErrorHandler,
+}
+
+export interface CreateBlockNumberCallHandlerResult {
+  handler: RpcHandler
+  incrementBlockNumber: () => void
+}
+export function createBlockNumberCallHandler(initialBlockNumber: bigint): CreateBlockNumberCallHandlerResult {
+  let blockNumber = initialBlockNumber
+
+  const incrementBlockNumber = () => {
+    blockNumber++
+  }
+
+  const handler: RpcHandler = (method, params) => {
+    return blockNumberCall(blockNumber)(method, params)
+  }
+
+  return { handler, incrementBlockNumber }
+}
+
+export interface CreateGetLogsHandlerResult {
+  handler: RpcHandler
+  setEnabled: (enabled: boolean) => void
+}
+export function createGetLogsHandler(opts: GetLogsCallOptions<AbiEvent>): CreateGetLogsHandlerResult {
+  let enabled = false
+
+  const setEnabled = (value: boolean) => {
+    enabled = value
+  }
+
+  const handler: RpcHandler = (method, params) => {
+    if (!enabled) {
+      if (method === 'eth_getLogs') {
+        return []
+      }
+
+      return undefined
+    }
+
+    return getLogsCall(opts)(method, params)
+  }
+
+  return { handler, setEnabled }
 }

--- a/packages/app/src/test/integration/wagmi-config.ts
+++ b/packages/app/src/test/integration/wagmi-config.ts
@@ -28,6 +28,7 @@ export function createWagmiTestConfig(options: CreateWagmiTestConfigOptions) {
     batch: {
       multicall: false,
     },
+    pollingInterval: 100,
   })
 }
 


### PR DESCRIPTION
- Replaces `webSocket` transport with `http` transport in default wagmi config.
- Refactors `useWaitForTransactionReceiptGnosisSafe` to actively query for logs on every new block, instead of using subscription mechanisms.
- Adds `getLogsCall` handler for integration tests.
- Adds `createBlockNumberCallHandler` and `createGetLogsHandler` which effectively allows to simulate blockchain state change in integration tests.  