### PR TITLE
Fix waiting for setup execution in borrow dialog E2E tests

### DIFF
--- a/packages/app/src/features/dialogs/borrow/BorrowDialog.test-e2e.ts
+++ b/packages/app/src/features/dialogs/borrow/BorrowDialog.test-e2e.ts
@@ -44,11 +44,9 @@ test.describe('Borrow dialog', () => {
       await borrowPage.viewInDashboardAction()
 
       const dashboardPage = new DashboardPageObject(page)
-      // @todo This waits for the refetch of the data after successful borrow transaction to happen.
-      // This is no ideal, probably we need to refactor expectDepositTable so it takes advantage from
-      // playwright's timeouts instead of parsing it's current state. Then we would be able to
-      // easily wait for the table to be updated.
-      await dashboardPage.expectAssetToBeInDepositTable('DAI')
+
+      // wait for all transactions to be executed
+      await dashboardPage.expectHealthFactor(expectedInitialHealthFactor)
     })
 
     test('opens dialog with selected asset', async ({ page }) => {


### PR DESCRIPTION
The previous waiting mechanism was flawed as we waited for DAI to appear in deposit table. This also included DAI appearing in wallet balances. Because wallet balances and market info are separate queries, we didn't actually wait for new market info to be fetched correctly, which could lead to situations where borrow dialog validation was stuck with outdated market info.