### PR TITLE
Increase sentry max value length

### DIFF
--- a/packages/app/src/utils/sentry.ts
+++ b/packages/app/src/utils/sentry.ts
@@ -15,6 +15,7 @@ Sentry.init({
   replaysSessionSampleRate: 0,
   replaysOnErrorSampleRate: 0,
   tracePropagationTargets: [],
+  maxValueLength: 5000,
   ignoreErrors: [
     'User rejected the request', // Rejecting a request using browser wallet
     'User rejected methods', // Happens sometimes with mobile wallets


### PR DESCRIPTION
All errors in sentry were trimmed to default `maxValueLength` parameter in Sentry - 250. This makes it impossible to fully read contract function execution errors, as they are oftentimes longer than 250 characters. This PR increases the `maxValueLength` to 5000.