### PR TITLE
Add historical data fetching for APR chart

### DIFF
--- a/packages/app/.env.production
+++ b/packages/app/.env.production
@@ -14,5 +14,5 @@ VITE_WALLET_CONNECT_ID='cc7986102d5c2d8448b57cb04d2fa005'
 VITE_ANALYTICS_PLAUSIBLE_ID='new-app.spark.fi'
 VITE_API_URL=https://api-v2.spark.fi/api/v1
 VITE_BLOCK_ANALITICA_API_URL=https://spark-api.blockanalitica.com/api
-VITE_MKR_ATLAS_API_URL=https://mkr-atlas-api.blockanalitica.com/api/v1
+VITE_INFO_SKY_API_URL=https://info-sky.blockanalitica.com/api/v1
 VITE_ENV_NAME=production

--- a/packages/app/.env.staging
+++ b/packages/app/.env.staging
@@ -14,5 +14,5 @@ VITE_WALLET_CONNECT_ID='bd1843f2419f5d4c758366c55f9a556c'
 VITE_ANALYTICS_PLAUSIBLE_ID=''
 VITE_API_URL=/api
 VITE_BLOCK_ANALITICA_API_URL=https://spark-api.blockanalitica.com/api
-VITE_MKR_ATLAS_API_URL=https://mkr-atlas-api.blockanalitica.com/api/v1
+VITE_INFO_SKY_API_URL=https://info-sky.blockanalitica.com/api/v1
 VITE_ENV_NAME=staging

--- a/packages/app/.storybook/decorators.tsx
+++ b/packages/app/.storybook/decorators.tsx
@@ -1,6 +1,6 @@
 import { StoryFn } from '@storybook/react'
 import { QueryClient, QueryClientConfig, QueryClientProvider } from '@tanstack/react-query'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { custom, encodeFunctionResult, zeroAddress } from 'viem'
 import { WagmiProvider, createConfig, useAccount, useConnect } from 'wagmi'
 
@@ -130,5 +130,19 @@ export function WithQueryClient(config?: QueryClientConfig) {
         <Story />
       </QueryClientProvider>
     )
+  }
+}
+
+export function WithFixedDate() {
+  return function WithFixedDate(Story: StoryFn) {
+    // biome-ignore lint/correctness/useHookAtTopLevel: the second one is the actual component that gets rendered
+    const firstRender = useRef(true)
+    if (firstRender.current) {
+      Date.now = () => 1724846808220
+
+      firstRender.current = false
+    }
+
+    return <Story />
   }
 }

--- a/packages/app/.storybook/decorators.tsx
+++ b/packages/app/.storybook/decorators.tsx
@@ -138,7 +138,7 @@ export function WithFixedDate() {
     // biome-ignore lint/correctness/useHookAtTopLevel: the second one is the actual component that gets rendered
     const firstRender = useRef(true)
     if (firstRender.current) {
-      Date.now = () => 1724846808220
+      Date.now = () => 1724846808220 // 2024-08-28T12:06:48.220Z
 
       firstRender.current = false
     }

--- a/packages/app/.storybook/preview.ts
+++ b/packages/app/.storybook/preview.ts
@@ -1,5 +1,5 @@
 import { withThemeByClassName } from '@storybook/addon-themes'
-import { WithI18n, WithQueryClient } from './decorators'
+import { WithFixedDate, WithI18n, WithQueryClient } from './decorators'
 
 import '../src/css/fonts.css'
 import '../src/css/main.css'
@@ -47,6 +47,7 @@ const preview: Preview = {
   decorators: [
     WithI18n(),
     WithQueryClient(),
+    WithFixedDate(),
     // Adds theme switching support.
     // NOTE: requires setting "darkMode" to "class" in your tailwind config
     // NOTE: order matters, this decorator must be the last one

--- a/packages/app/src/config/consts.ts
+++ b/packages/app/src/config/consts.ts
@@ -16,7 +16,7 @@ export const ZUSTAND_APP_STORE_LOCAL_STORAGE_VERSION = 2
 
 export const apiUrl = import.meta.env.VITE_API_URL ?? '/api'
 export const blockAnaliticaApiUrl = import.meta.env.VITE_BLOCK_ANALITICA_API_URL ?? '/ba-api'
-export const mkrAtlasApiUrl = import.meta.env.VITE_MKR_ATLAS_API_URL ?? '/mkr-atlas-api'
+export const infoSkyApiUrl = import.meta.env.VITE_INFO_SKY_API_URL ?? '/info-sky-api'
 
 // @note: all sandboxes created by the app begin (when expressed as strings) with this chain id. Ex: 30301719211032
 export const SANDBOX_NETWORKS_CHAIN_ID_PREFIX = 3030

--- a/packages/app/src/config/paths.ts
+++ b/packages/app/src/config/paths.ts
@@ -5,5 +5,5 @@ export const paths = {
   savings: '/savings',
   farms: '/farms',
   marketDetails: '/market-details/:chainId/:asset',
-  farmDetails: '/farm-details/:chainId/:farm',
+  farmDetails: '/farm-details/:chainId/:address',
 } as const

--- a/packages/app/src/domain/farms/getFarm.ts
+++ b/packages/app/src/domain/farms/getFarm.ts
@@ -1,5 +1,5 @@
 import { stakingRewardsAbi } from '@/config/abis/stakingRewardsAbi'
-import { mkrAtlasApiUrl } from '@/config/consts'
+import { infoSkyApiUrl } from '@/config/consts'
 import { FarmConfig } from '@/domain/farms/types'
 import { CheckedAddress } from '@/domain/types/CheckedAddress'
 import { BaseUnitNumber, NormalizedUnitNumber, Percentage } from '@/domain/types/NumericValues'
@@ -14,12 +14,13 @@ export interface GetFarmParams {
   farmConfig: FarmConfig
   wagmiConfig: Config
   tokensInfo: TokensInfo
+  chainId: number
   account: Address | undefined
 }
 
-export async function getFarm({ farmConfig, wagmiConfig, tokensInfo, account }: GetFarmParams): Promise<Farm> {
+export async function getFarm({ farmConfig, wagmiConfig, tokensInfo, chainId, account }: GetFarmParams): Promise<Farm> {
   const [contractData, baData] = await Promise.all([
-    getFarmContractData({ farmConfig, wagmiConfig, account }),
+    getFarmContractData({ farmConfig, wagmiConfig, chainId, account }),
     getBAFarmData({ farmConfig }),
   ])
 
@@ -45,6 +46,7 @@ export async function getFarm({ farmConfig, wagmiConfig, tokensInfo, account }: 
 interface GetFarmContractDataParams {
   farmConfig: FarmConfig
   wagmiConfig: Config
+  chainId: number
   account: Address | undefined
 }
 
@@ -62,6 +64,7 @@ interface GetFarmContractDataResult {
 async function getFarmContractData({
   farmConfig,
   wagmiConfig,
+  chainId,
   account,
 }: GetFarmContractDataParams): Promise<GetFarmContractDataResult> {
   function getStaked(): Promise<bigint> {
@@ -74,6 +77,7 @@ async function getFarmContractData({
       abi: stakingRewardsAbi,
       functionName: 'balanceOf',
       args: [account],
+      chainId,
     })
 
     return res
@@ -89,6 +93,7 @@ async function getFarmContractData({
       abi: stakingRewardsAbi,
       functionName: 'earned',
       args: [account],
+      chainId,
     })
 
     return res
@@ -110,31 +115,37 @@ async function getFarmContractData({
       address: farmConfig.address,
       abi: stakingRewardsAbi,
       functionName: 'rewardsToken',
+      chainId,
     }),
     readContract(wagmiConfig, {
       address: farmConfig.address,
       abi: stakingRewardsAbi,
       functionName: 'stakingToken',
+      chainId,
     }),
     readContract(wagmiConfig, {
       address: farmConfig.address,
       abi: stakingRewardsAbi,
       functionName: 'rewardRate',
+      chainId,
     }),
     readContract(wagmiConfig, {
       address: farmConfig.address,
       abi: stakingRewardsAbi,
       functionName: 'lastTimeRewardApplicable',
+      chainId,
     }),
     readContract(wagmiConfig, {
       address: farmConfig.address,
       abi: stakingRewardsAbi,
       functionName: 'periodFinish',
+      chainId,
     }),
     readContract(wagmiConfig, {
       address: farmConfig.address,
       abi: stakingRewardsAbi,
       functionName: 'totalSupply',
+      chainId,
     }),
   ])
 
@@ -159,7 +170,7 @@ interface GetFarmBADataResult {
 }
 
 async function getBAFarmData({ farmConfig }: GetFarmBADataParams): Promise<GetFarmBADataResult> {
-  const res = await fetch(`${mkrAtlasApiUrl}/farms/${farmConfig.address.toLowerCase()}/`)
+  const res = await fetch(`${infoSkyApiUrl}/farms/${farmConfig.address.toLowerCase()}/`)
   if (!res.ok) {
     throw new Error(`Failed to fetch farm data: ${res.statusText}`)
   }

--- a/packages/app/src/domain/farms/query.ts
+++ b/packages/app/src/domain/farms/query.ts
@@ -26,7 +26,7 @@ export function farmsInfoQueryOptions({
     queryKey: getFarmsInfoQueryKey({ account, chainId }),
     queryFn: async () => {
       const farms = await Promise.all(
-        farmConfigs.map((farmConfig) => getFarm({ farmConfig, wagmiConfig, tokensInfo, account })),
+        farmConfigs.map((farmConfig) => getFarm({ farmConfig, wagmiConfig, tokensInfo, chainId, account })),
       )
       return new FarmsInfo(farms)
     },

--- a/packages/app/src/domain/farms/useFarmsInfo.ts
+++ b/packages/app/src/domain/farms/useFarmsInfo.ts
@@ -6,16 +6,22 @@ import { useAccount, useChainId, useConfig } from 'wagmi'
 import { FarmsInfo } from './farmsInfo'
 import { farmsInfoQueryOptions } from './query'
 
-export type UseMarketInfoResultOnSuccess = SuspenseQueryWith<{
+export interface UseFarmsInfoParams {
+  chainId?: number
+}
+
+export type UseFarmsInfoResultOnSuccess = SuspenseQueryWith<{
   farmsInfo: FarmsInfo
 }>
 
-export function useFarmsInfo(): UseMarketInfoResultOnSuccess {
+export function useFarmsInfo(params: UseFarmsInfoParams = {}): UseFarmsInfoResultOnSuccess {
   const wagmiConfig = useConfig()
   const { address: account } = useAccount()
-  const chainId = useChainId()
+  const _chainId = useChainId()
+  const chainId = params.chainId ?? _chainId
+
   const chainConfig = getChainConfigEntry(chainId)
-  const { tokensInfo } = useTokensInfo({ tokens: chainConfig.extraTokens })
+  const { tokensInfo } = useTokensInfo({ tokens: chainConfig.extraTokens, chainId })
 
   const res = useSuspenseQuery(
     farmsInfoQueryOptions({ farmConfigs: chainConfig.farms, wagmiConfig, tokensInfo, chainId, account }),

--- a/packages/app/src/domain/wallet/useTokens/createOraclePriceFetcher.ts
+++ b/packages/app/src/domain/wallet/useTokens/createOraclePriceFetcher.ts
@@ -7,11 +7,13 @@ import { TokenConfig } from './types'
 export interface CreateOraclePriceFetcherParams {
   tokenConfig: TokenConfig
   wagmiConfig: Config
+  chainId: number
 }
 
 export function createOraclePriceFetcher({
   tokenConfig,
   wagmiConfig,
+  chainId,
 }: CreateOraclePriceFetcherParams): () => Promise<NormalizedUnitNumber> {
   if (tokenConfig.oracleType === 'fixed-usd') {
     return async () => NormalizedUnitNumber(1)
@@ -24,6 +26,7 @@ export function createOraclePriceFetcher({
         address: tokenConfig.address,
         functionName: 'convertToAssets',
         args: [parseUnits('1', etherUnits.wei)],
+        chainId,
       })
 
       return NormalizedUnitNumber(formatUnits(result, etherUnits.wei))

--- a/packages/app/src/domain/wallet/useTokens/query.ts
+++ b/packages/app/src/domain/wallet/useTokens/query.ts
@@ -1,5 +1,4 @@
 import { getChainConfigEntry } from '@/config/chain'
-import { getNativeAssetInfo } from '@/config/chain/utils/getNativeAssetInfo'
 import { queryOptions } from '@tanstack/react-query'
 import { Address } from 'viem'
 import { Config } from 'wagmi'
@@ -24,12 +23,11 @@ export function tokensQueryOptions({ tokens, wagmiConfig, chainId, account }: To
     queryKey: tokensQueryKey({ tokens, account, chainId }),
     queryFn: async () => {
       const chainConfig = getChainConfigEntry(chainId)
-      const nativeAssetInfo = getNativeAssetInfo(chainId)
 
       const tokensWithBalances = await Promise.all(
         tokens.map(async (tokenConfig) => {
-          const getOraclePrice = createOraclePriceFetcher({ tokenConfig, wagmiConfig })
-          const getAssetData = createAssetDataFetcher({ tokenConfig, wagmiConfig, nativeAssetInfo, account })
+          const getOraclePrice = createOraclePriceFetcher({ tokenConfig, wagmiConfig, chainId })
+          const getAssetData = createAssetDataFetcher({ tokenConfig, wagmiConfig, chainId, account })
 
           const [assetData, oraclePrice] = await Promise.all([getAssetData(), getOraclePrice()])
 

--- a/packages/app/src/domain/wallet/useTokens/useTokensInfo.ts
+++ b/packages/app/src/domain/wallet/useTokens/useTokensInfo.ts
@@ -8,16 +8,18 @@ import { TokenConfig } from './types'
 
 export interface UseTokensParams {
   tokens: TokenConfig[]
+  chainId?: number
 }
 
 export type UseTokensResult = SuspenseQueryWith<{
   tokensInfo: TokensInfo
 }>
 
-export function useTokensInfo({ tokens }: UseTokensParams): UseTokensResult {
+export function useTokensInfo(params: UseTokensParams): UseTokensResult {
   const wagmiConfig = useConfig()
   const { address } = useAccount()
-  const chainId = useChainId()
+  const _chainId = useChainId()
+  const { tokens, chainId = _chainId } = params
 
   const response = useSuspenseQuery({
     ...tokensQueryOptions({

--- a/packages/app/src/features/farm-details/FarmDetailsContainer.tsx
+++ b/packages/app/src/features/farm-details/FarmDetailsContainer.tsx
@@ -5,9 +5,9 @@ import { useFarmDetails } from './logic/useFarmDetails'
 import { FarmDetailsView } from './views/FarmDetailsView'
 
 function FarmDetailsContainer() {
-  const farmDetails = useFarmDetails()
+  useFarmDetails()
 
-  return <FarmDetailsView {...farmDetails} />
+  return <FarmDetailsView />
 }
 
 const FarmDetailsContainerWithSuspense = withSuspense(FarmDetailsContainer, FarmDetailsSkeleton)

--- a/packages/app/src/features/farm-details/components/active-farm-info-panel/EarnedBalance.tsx
+++ b/packages/app/src/features/farm-details/components/active-farm-info-panel/EarnedBalance.tsx
@@ -6,7 +6,6 @@ import BigNumber from 'bignumber.js'
 import { FarmInfo } from '../../types'
 
 const STEP_IN_MS = 50
-const MS_IN_A_MONTH = 30 * 24 * 60 * 60 * 1000
 
 export interface EarnedBalanceProps {
   FarmInfo: FarmInfo
@@ -16,11 +15,9 @@ export function EarnedBalance({ FarmInfo }: EarnedBalanceProps) {
   const { rewardToken, earned, staked, rewardRate, earnedTimestamp, periodFinish, totalSupply } = FarmInfo
   // disable in storybook preview to avoid change detection in chromatic
   const shouldRefresh = rewardRate.gt(0) && totalSupply.gt(0) && !import.meta.env.STORYBOOK_PREVIEW
-  const { timestampInMs: _timestampInMs } = useTimestamp({
+  const { timestampInMs } = useTimestamp({
     refreshIntervalInMs: shouldRefresh ? STEP_IN_MS : undefined,
   })
-  // fix timestamp in storybook preview to avoid change detection in chromatic
-  const timestampInMs = import.meta.env.STORYBOOK_PREVIEW ? _timestampInMs + MS_IN_A_MONTH : _timestampInMs
 
   const currentEarned = calculateCurrentlyEarned({
     earned,
@@ -28,7 +25,7 @@ export function EarnedBalance({ FarmInfo }: EarnedBalanceProps) {
     rewardRate,
     earnedTimestamp,
     periodFinish,
-    timestampInMs,
+    timestampInMs: import.meta.env.STORYBOOK_PREVIEW ? 1724846808220 : timestampInMs,
     totalSupply,
   })
   const precision = calculatePrecision({ staked, rewardRate })

--- a/packages/app/src/features/farm-details/components/active-farm-info-panel/EarnedBalance.tsx
+++ b/packages/app/src/features/farm-details/components/active-farm-info-panel/EarnedBalance.tsx
@@ -13,10 +13,8 @@ export interface EarnedBalanceProps {
 
 export function EarnedBalance({ FarmInfo }: EarnedBalanceProps) {
   const { rewardToken, earned, staked, rewardRate, earnedTimestamp, periodFinish, totalSupply } = FarmInfo
-  // disable in storybook preview to avoid change detection in chromatic
-  const shouldRefresh = rewardRate.gt(0) && totalSupply.gt(0) && !import.meta.env.STORYBOOK_PREVIEW
   const { timestampInMs } = useTimestamp({
-    refreshIntervalInMs: shouldRefresh ? STEP_IN_MS : undefined,
+    refreshIntervalInMs: rewardRate.gt(0) && totalSupply.gt(0) ? STEP_IN_MS : undefined,
   })
 
   const currentEarned = calculateCurrentlyEarned({
@@ -25,7 +23,7 @@ export function EarnedBalance({ FarmInfo }: EarnedBalanceProps) {
     rewardRate,
     earnedTimestamp,
     periodFinish,
-    timestampInMs: import.meta.env.STORYBOOK_PREVIEW ? 1724846808220 : timestampInMs,
+    timestampInMs,
     totalSupply,
   })
   const precision = calculatePrecision({ staked, rewardRate })

--- a/packages/app/src/features/farm-details/logic/historic/query.ts
+++ b/packages/app/src/features/farm-details/logic/historic/query.ts
@@ -1,0 +1,36 @@
+import { infoSkyApiUrl } from '@/config/consts'
+import { Percentage } from '@/domain/types/NumericValues'
+import { queryOptions } from '@tanstack/react-query'
+import BigNumber from 'bignumber.js'
+import { z } from 'zod'
+
+export interface FarmHistoricDataParameters {
+  chainId: number
+  farmAddress: string
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export function farmHistoricDataQueryOptions({ chainId, farmAddress }: FarmHistoricDataParameters) {
+  return queryOptions({
+    queryKey: ['farm-historic-data', chainId, farmAddress],
+    queryFn: async () => {
+      const res = await fetch(`${infoSkyApiUrl}/farms/${farmAddress.toLowerCase()}/historic/`)
+      if (!res.ok) {
+        throw new Error(`Failed to fetch farm data: ${res.statusText}`)
+      }
+
+      return historicDataResponseSchema.parse(await res.json())
+    },
+  })
+}
+
+const historicDataResponseSchema = z
+  .object({
+    results: z.array(
+      z.object({
+        date: z.string().transform((value) => new Date(value)),
+        apr: z.string().transform((value) => Percentage(BigNumber(value).div(100), true)),
+      }),
+    ),
+  })
+  .transform((value) => value.results)

--- a/packages/app/src/features/farm-details/logic/historic/types.ts
+++ b/packages/app/src/features/farm-details/logic/historic/types.ts
@@ -1,0 +1,6 @@
+import { Percentage } from '@/domain/types/NumericValues'
+
+export interface FarmHistoryItem {
+  date: Date
+  apr: Percentage
+}

--- a/packages/app/src/features/farm-details/logic/historic/useFarmHistoricData.ts
+++ b/packages/app/src/features/farm-details/logic/historic/useFarmHistoricData.ts
@@ -1,0 +1,25 @@
+import { SuspenseQueryWith } from '@/utils/types'
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { farmHistoricDataQueryOptions } from './query'
+import { FarmHistoryItem } from './types'
+
+export interface UseFarmHistoricDataParams {
+  chainId: number
+  farmAddress: string
+}
+
+export type UseFarmHistoricDataResultOnSuccess = SuspenseQueryWith<{
+  farmHistoricData: FarmHistoryItem[]
+}>
+
+export function useFarmHistoricData({
+  chainId,
+  farmAddress,
+}: UseFarmHistoricDataParams): UseFarmHistoricDataResultOnSuccess {
+  const res = useSuspenseQuery(farmHistoricDataQueryOptions({ chainId, farmAddress }))
+
+  return {
+    ...res,
+    farmHistoricData: res.data,
+  }
+}

--- a/packages/app/src/features/farm-details/logic/useFarmDetails.ts
+++ b/packages/app/src/features/farm-details/logic/useFarmDetails.ts
@@ -1,3 +1,24 @@
-export function useFarmDetails(): {} {
-  return {}
+import { NotFoundError } from '@/domain/errors/not-found'
+import { Farm } from '@/domain/farms/types'
+import { useFarmsInfo } from '@/domain/farms/useFarmsInfo'
+import { raise } from '@/utils/assert'
+import { FarmHistoryItem } from './historic/types'
+import { useFarmHistoricData } from './historic/useFarmHistoricData'
+import { useFarmDetailsParams } from './useFarmDetailsParams'
+
+export interface UseFarmDetailsResult {
+  farm: Farm
+  farmHistoricData: FarmHistoryItem[]
+}
+
+export function useFarmDetails(): UseFarmDetailsResult {
+  const { address: farmAddress, chainId } = useFarmDetailsParams()
+  const { farmsInfo } = useFarmsInfo({ chainId })
+  const farm = farmsInfo.findFarmByAddress(farmAddress) ?? raise(new NotFoundError())
+  const { farmHistoricData } = useFarmHistoricData({ chainId, farmAddress })
+
+  return {
+    farm,
+    farmHistoricData,
+  }
 }

--- a/packages/app/src/features/farm-details/logic/useFarmDetailsParams.ts
+++ b/packages/app/src/features/farm-details/logic/useFarmDetailsParams.ts
@@ -7,7 +7,7 @@ import { useValidatedParams } from '@/utils/useValidatedParams'
 
 const farmDetailsUrlSchema = z.object({
   chainId: z.coerce.number(),
-  farm: checkedAddressSchema,
+  address: checkedAddressSchema,
 })
 
 export function useFarmDetailsParams(): z.infer<typeof farmDetailsUrlSchema> {

--- a/packages/app/src/features/farms/logic/getFarmTileData.ts
+++ b/packages/app/src/features/farms/logic/getFarmTileData.ts
@@ -10,7 +10,7 @@ export interface GetFarmTileDataParams {
 export function getFarmTileProps({ farm, chainId }: GetFarmTileDataParams): FarmTileProps {
   return {
     apy: farm.apy,
-    detailsLink: generatePath(paths.farmDetails, { chainId: chainId.toString(), farm: farm.address }),
+    detailsLink: generatePath(paths.farmDetails, { chainId: chainId.toString(), address: farm.address }),
     entryAssetsGroup: farm.entryAssetsGroup,
     rewardToken: farm.rewardToken,
     stakingToken: farm.stakingToken,

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -47,10 +47,10 @@ export default defineConfig({
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/ba-api/, ''),
       },
-      '/mkr-atlas-api': {
-        target: 'https://mkr-atlas-api.blockanalitica.com/api/v1/',
+      '/info-sky-api': {
+        target: 'https://info-sky.blockanalitica.com/api/v1/',
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/mkr-atlas-api/, ''),
+        rewrite: (path) => path.replace(/^\/info-sky-api/, ''),
       },
     },
   },


### PR DESCRIPTION
- Adds `useFarmHistoricData` hook
- Adds simple version of `useFarmDetails` hook
- Fixes timestamp in stories