### PR TITLE
Tweak playwright configuration to fail after few failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,10 @@
     "tsx": "^4.15.6",
     "typescript": "^5.6.2",
     "typescript-eslint": "^7.11.0"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "playwright@1.47.2": "patches/playwright@1.47.2.patch"
+    }
   }
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -92,7 +92,7 @@
     "@lingui/conf": "^4.5.0",
     "@lingui/swc-plugin": "^4.0.4",
     "@lingui/vite-plugin": "^4.5.0",
-    "@playwright/test": "^1.43.0",
+    "@playwright/test": "^1.47.2",
     "@sentry/react": "^7.114.0",
     "@storybook/addon-essentials": "^8.1.4",
     "@storybook/addon-interactions": "^8.1.4",

--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     timeout: 20_000,
   },
   timeout: 60_000 * 3, // sometimes tenderly can be slow
-  maxFailures: 1, // should mark test as failed only after all retires are exhausted
+  maxFailures: 3, // should mark test as failed only after all retires are exhausted
 
   webServer: {
     command: 'pnpm build --mode playwright && pnpm exec serve dist -sL -p 4000',

--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     timeout: 20_000,
   },
   timeout: 60_000 * 3, // sometimes tenderly can be slow
-  maxFailures: undefined, // don't use this as it doesn't respect retires
+  maxFailures: 1, // should mark test as failed only after all retires are exhausted
 
   webServer: {
     command: 'pnpm build --mode playwright && pnpm exec serve dist -sL -p 4000',

--- a/packages/app/src/features/dialogs/savings/deposit/e2e/mainnet/DepositUSDC.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/deposit/e2e/mainnet/DepositUSDC.test-e2e.ts
@@ -47,7 +47,7 @@ test.describe('Deposit USDC', () => {
         },
         routeItems: [
           {
-            tokenAmount: '20,000.00 USDC',
+            tokenAmount: '10,000.00 USDC',
             tokenUsdValue: '$10,000.00',
           },
           {

--- a/packages/app/src/features/dialogs/savings/deposit/e2e/mainnet/DepositUSDC.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/deposit/e2e/mainnet/DepositUSDC.test-e2e.ts
@@ -47,7 +47,7 @@ test.describe('Deposit USDC', () => {
         },
         routeItems: [
           {
-            tokenAmount: '10,000.00 USDC',
+            tokenAmount: '20,000.00 USDC',
             tokenUsdValue: '$10,000.00',
           },
           {

--- a/patches/playwright@1.47.2.patch
+++ b/patches/playwright@1.47.2.patch
@@ -1,0 +1,15 @@
+diff --git a/lib/runner/failureTracker.js b/lib/runner/failureTracker.js
+index b5d0e761af9222fddcaf772058802471a17d6fc8..2abd7c4aaeb5dced62cfdef2659d501c3eb46801 100644
+--- a/lib/runner/failureTracker.js
++++ b/lib/runner/failureTracker.js
+@@ -31,7 +31,9 @@ class FailureTracker {
+     this._rootSuite = rootSuite;
+   }
+   onTestEnd(test, result) {
+-    if (result.status !== 'skipped' && result.status !== test.expectedStatus) ++this._failureCount;
++    // Test is considered failing after the last retry.
++    if (test.outcome() === 'unexpected' && test.results.length > test.retries)
++      ++this._failureCount;
+   }
+   onWorkerError() {
+     this._hasWorkerErrors = true;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,8 +226,8 @@ importers:
         specifier: ^4.5.0
         version: 4.10.1(vite@5.2.11)
       '@playwright/test':
-        specifier: ^1.43.0
-        version: 1.43.0
+        specifier: ^1.47.2
+        version: 1.47.2
       '@sentry/react':
         specifier: ^7.114.0
         version: 7.114.0(react@18.2.0)
@@ -5796,12 +5796,12 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@playwright/test@1.43.0:
-    resolution: {integrity: sha512-Ebw0+MCqoYflop7wVKj711ccbNlrwTBCtjY5rlbiY9kHL2bCYxq+qltK6uPsVBGGAOb033H2VO0YobcQVxoW7Q==}
-    engines: {node: '>=16'}
+  /@playwright/test@1.47.2:
+    resolution: {integrity: sha512-jTXRsoSPONAs8Za9QEQdyjFn+0ZQFjCiIztAIF6bi1HqhBzG9Ma7g1WotyiGqFSBRZjIEqMdT8RUlbk1QVhzCQ==}
+    engines: {node: '>=18'}
     hasBin: true
     dependencies:
-      playwright: 1.43.0
+      playwright: 1.47.2
     dev: true
 
   /@radix-ui/number@1.0.1:
@@ -15911,18 +15911,18 @@ packages:
       find-up: 3.0.0
     dev: true
 
-  /playwright-core@1.43.0:
-    resolution: {integrity: sha512-iWFjyBUH97+pUFiyTqSLd8cDMMOS0r2ZYz2qEsPjH8/bX++sbIJT35MSwKnp1r/OQBAqC5XO99xFbJ9XClhf4w==}
-    engines: {node: '>=16'}
+  /playwright-core@1.47.2:
+    resolution: {integrity: sha512-3JvMfF+9LJfe16l7AbSmU555PaTl2tPyQsVInqm3id16pdDfvZ8TTZ/pyzmkbDrZTQefyzU7AIHlZqQnxpqHVQ==}
+    engines: {node: '>=18'}
     hasBin: true
     dev: true
 
-  /playwright@1.43.0:
-    resolution: {integrity: sha512-SiOKHbVjTSf6wHuGCbqrEyzlm6qvXcv7mENP+OZon1I07brfZLGdfWV0l/efAzVx7TF3Z45ov1gPEkku9q25YQ==}
-    engines: {node: '>=16'}
+  /playwright@1.47.2:
+    resolution: {integrity: sha512-nx1cLMmQWqmA3UsnjaaokyoUpdVaaDhJhMoxX2qj3McpjnsqFHs516QAKYhqHAgOP+oCFTEOCOAaD1RgD/RQfA==}
+    engines: {node: '>=18'}
     hasBin: true
     dependencies:
-      playwright-core: 1.43.0
+      playwright-core: 1.47.2
     optionalDependencies:
       fsevents: 2.3.2
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  playwright@1.47.2:
+    hash: typtw5ccupt37wcd4eaee4rmte
+    path: patches/playwright@1.47.2.patch
+
 importers:
 
   .:
@@ -5801,7 +5806,7 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
     dependencies:
-      playwright: 1.47.2
+      playwright: 1.47.2(patch_hash=typtw5ccupt37wcd4eaee4rmte)
     dev: true
 
   /@radix-ui/number@1.0.1:
@@ -15917,7 +15922,7 @@ packages:
     hasBin: true
     dev: true
 
-  /playwright@1.47.2:
+  /playwright@1.47.2(patch_hash=typtw5ccupt37wcd4eaee4rmte):
     resolution: {integrity: sha512-nx1cLMmQWqmA3UsnjaaokyoUpdVaaDhJhMoxX2qj3McpjnsqFHs516QAKYhqHAgOP+oCFTEOCOAaD1RgD/RQfA==}
     engines: {node: '>=18'}
     hasBin: true
@@ -15926,6 +15931,7 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
+    patched: true
 
   /pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}


### PR DESCRIPTION
It looks like fix is not yet available on latest release. I looked at [PR](https://github.com/microsoft/playwright/issues/26350), and it has label `1.48` attached, while the current release is `1.47.2`. I suspect it might take some time until available.

EDIT: I've patched playwright to include given fix.