### PR TITLE
Adjust playwright test config to get test report faster

### DIFF
--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   testDir: './src',
   testMatch: '**/*.test-e2e.ts',
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 3 : 0,
+  retries: process.env.CI ? 2 : 0,
   // CI will use all available cores
   workers: process.env.CI || process.env.PLAYWRIGHT_PARALLEL ? '100%' : 1,
   reporter: 'html',
@@ -20,8 +20,8 @@ export default defineConfig({
   expect: {
     timeout: 20_000,
   },
-  timeout: 60_000 * 3, // sometimes tenderly can be slow
-  maxFailures: 3, // should mark test as failed only after all retires are exhausted
+  timeout: 60_000 * 2, // sometimes tenderly can be slow
+  maxFailures: 1, // should mark test as failed only after all retires are exhausted
 
   webServer: {
     command: 'pnpm build --mode playwright && pnpm exec serve dist -sL -p 4000',


### PR DESCRIPTION
Closes FRO-1008

`maxFailures` flag works best when tests are running with only one worker.
In case when we have multiple failing tests in tests suits from same directory, playwright will distribute those tests among 16 workers. Each of this tests can hit timeout (3 minutes, e.g., when locator is wrongly written). So in final, we had:
- one failed test: 3 minutes
- 3 retries each of them 3 minutes
- in total 12 minutes for one test to be marked as failed
If `maxFailures` is set to more than `1`, first worker available will take and run another test, which will add to the pile.

This PR is reproduction of yesterday's failing PR, in which 20 min timeout was hit, but with slightly modified playwright config to check if tests will give result faster:
- maxFailures = 1
- timeout = 2 minutes
- retries = 2