### PR TITLE
Refactor savings counter rendering

### DIFF
--- a/packages/app/.storybook/tokens.ts
+++ b/packages/app/.storybook/tokens.ts
@@ -12,7 +12,7 @@ export const tokens = {
     address: CheckedAddress('0x7D5afF7ab67b431cDFA6A94d50d3124cC4AB2611'),
   }),
   DAI: new Token({
-    unitPriceUsd: '1.00001023',
+    unitPriceUsd: '1',
     symbol: TokenSymbol('DAI'),
     name: 'Dai Stablecoin',
     decimals: 18,

--- a/packages/app/src/features/savings/components/growing-balance/GrowingBalance.tsx
+++ b/packages/app/src/features/savings/components/growing-balance/GrowingBalance.tsx
@@ -1,0 +1,50 @@
+import { TokenWithBalance } from '@/domain/common/types'
+import { Token } from '@/domain/types/Token'
+import { getTokenImage } from '@/ui/assets'
+import { testIds } from '@/ui/utils/testIds'
+import { getFractionalPart, getWholePart } from '@/utils/bigNumber'
+import { useTimestamp } from '@/utils/useTimestamp'
+import { SavingsOverview } from '../../logic/makeSavingsOverview'
+
+export interface GrowingBalanceProps {
+  savingsTokenWithBalance: TokenWithBalance
+  assetsToken: Token
+  calculateSavingsBalance: (timestampInMs: number) => SavingsOverview
+  balanceRefreshIntervalInMs: number | undefined
+}
+
+export function GrowingBalance({
+  savingsTokenWithBalance,
+  assetsToken,
+  calculateSavingsBalance,
+  balanceRefreshIntervalInMs,
+}: GrowingBalanceProps) {
+  const { timestampInMs } = useTimestamp({ refreshIntervalInMs: balanceRefreshIntervalInMs })
+  const { depositedAssets, depositedAssetsPrecision } = calculateSavingsBalance(timestampInMs)
+
+  return (
+    <div className="flex flex-col items-center gap-1 sm:gap-2">
+      <div className="flex flex-row items-center gap-1.5 md:gap-3">
+        <img src={getTokenImage(assetsToken.symbol)} className="h-5 md:h-8" />
+        <div
+          className="flex flex-row items-end justify-center slashed-zero tabular-nums"
+          data-testid={testIds.savings.sDaiBalanceInDai}
+        >
+          <div className="font-semibold text-3xl md:text-5xl">{getWholePart(depositedAssets)}</div>
+          {depositedAssetsPrecision > 0 && (
+            <div className="font-semibold text-lg md:text-2xl">
+              {getFractionalPart(depositedAssets, depositedAssetsPrecision)}
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="font-semibold text-basics-dark-grey text-xs tracking-wide">
+        =
+        <span data-testid={testIds.savings.sDaiBalance}>
+          {savingsTokenWithBalance.token.format(savingsTokenWithBalance.balance, { style: 'auto' })}{' '}
+          {savingsTokenWithBalance.token.symbol}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/packages/app/src/features/savings/components/savings-token-panel/SavingsTokenPanel.stories.ts
+++ b/packages/app/src/features/savings/components/savings-token-panel/SavingsTokenPanel.stories.ts
@@ -45,6 +45,7 @@ export const DaiTablet: Story = getTabletStory(Dai)
 export const USDS: Story = {
   args: {
     variant: 'usds',
+    assetsToken: tokens.USDS,
     savingsTokenWithBalance: { balance: NormalizedUnitNumber(20000.0), token: tokens.sUSDS },
   },
 }

--- a/packages/app/src/features/savings/components/savings-token-panel/SavingsTokenPanel.stories.ts
+++ b/packages/app/src/features/savings/components/savings-token-panel/SavingsTokenPanel.stories.ts
@@ -1,12 +1,10 @@
+import { NormalizedUnitNumber, Percentage } from '@/domain/types/NumericValues'
+import { TokenSymbol } from '@/domain/types/TokenSymbol'
 import { WithClassname, WithTooltipProvider } from '@storybook/decorators'
 import type { Meta, StoryObj } from '@storybook/react'
 import { tokens } from '@storybook/tokens'
 import { getMobileStory, getTabletStory } from '@storybook/viewports'
 import { mainnet } from 'viem/chains'
-
-import { NormalizedUnitNumber, Percentage } from '@/domain/types/NumericValues'
-
-import { TokenSymbol } from '@/domain/types/TokenSymbol'
 import { SavingsTokenPanel } from './SavingsTokenPanel'
 
 const meta: Meta<typeof SavingsTokenPanel> = {
@@ -15,9 +13,13 @@ const meta: Meta<typeof SavingsTokenPanel> = {
   decorators: [WithTooltipProvider(), WithClassname('max-w-2xl')],
   args: {
     variant: 'dai',
-    depositedUSD: NormalizedUnitNumber(20765.7654),
-    depositedUSDPrecision: 4,
-    tokenWithBalance: { balance: NormalizedUnitNumber(20000.0), token: tokens.sDAI },
+    savingsTokenWithBalance: { balance: NormalizedUnitNumber(20000.0), token: tokens.sDAI },
+    assetsToken: tokens.DAI,
+    balanceRefreshIntervalInMs: 50,
+    calculateSavingsBalance: () => ({
+      depositedAssets: NormalizedUnitNumber(20765.7654),
+      depositedAssetsPrecision: 4,
+    }),
     APY: Percentage(0.05),
     originChainId: mainnet.id,
     savingsMetaItem: {
@@ -43,6 +45,6 @@ export const DaiTablet: Story = getTabletStory(Dai)
 export const USDS: Story = {
   args: {
     variant: 'usds',
-    tokenWithBalance: { balance: NormalizedUnitNumber(20000.0), token: tokens.sUSDS },
+    savingsTokenWithBalance: { balance: NormalizedUnitNumber(20000.0), token: tokens.sUSDS },
   },
 }

--- a/packages/app/src/features/savings/components/savings-token-panel/SavingsTokenPanel.tsx
+++ b/packages/app/src/features/savings/components/savings-token-panel/SavingsTokenPanel.tsx
@@ -2,25 +2,24 @@ import { SupportedChainId } from '@/config/chain/types'
 import { formatPercentage } from '@/domain/common/format'
 import { TokenWithBalance } from '@/domain/common/types'
 import { OpenDialogFunction } from '@/domain/state/dialogs'
-import { NormalizedUnitNumber, Percentage } from '@/domain/types/NumericValues'
-import { USD_MOCK_TOKEN } from '@/domain/types/Token'
-import { TokenSymbol } from '@/domain/types/TokenSymbol'
+import { Percentage } from '@/domain/types/NumericValues'
+import { Token } from '@/domain/types/Token'
 import { savingsWithdrawDialogConfig } from '@/features/dialogs/savings/withdraw/SavingsWithdrawDialog'
-import { getTokenImage } from '@/ui/assets'
 import { Button } from '@/ui/atoms/button/Button'
 import { Panel } from '@/ui/atoms/panel/Panel'
-import { testIds } from '@/ui/utils/testIds'
-import { getFractionalPart, getWholePart } from '@/utils/bigNumber'
 import { SavingsMetaItem } from '../../logic/makeSavingsMeta'
+import { SavingsOverview } from '../../logic/makeSavingsOverview'
 import { Projections } from '../../types'
+import { GrowingBalance } from '../growing-balance/GrowingBalance'
 import { SavingsInfoTile } from '../savings-info-tile/SavingsInfoTile'
 import { DSRLabel } from '../savings-opportunity/components/DSRLabel'
 
 export interface SavingsTokenPanelProps {
   variant: 'dai' | 'usds'
-  depositedUSD: NormalizedUnitNumber
-  depositedUSDPrecision: number
-  tokenWithBalance: TokenWithBalance
+  savingsTokenWithBalance: TokenWithBalance
+  assetsToken: Token
+  calculateSavingsBalance: (timestampInMs: number) => SavingsOverview
+  balanceRefreshIntervalInMs: number | undefined
   APY: Percentage
   originChainId: SupportedChainId
   currentProjections: Projections
@@ -30,9 +29,10 @@ export interface SavingsTokenPanelProps {
 
 export function SavingsTokenPanel({
   variant,
-  depositedUSD,
-  depositedUSDPrecision,
-  tokenWithBalance,
+  savingsTokenWithBalance,
+  assetsToken,
+  calculateSavingsBalance,
+  balanceRefreshIntervalInMs,
   APY,
   originChainId,
   currentProjections,
@@ -40,9 +40,6 @@ export function SavingsTokenPanel({
   savingsMetaItem,
 }: SavingsTokenPanelProps) {
   const compactProjections = currentProjections.thirtyDays.gt(1_000)
-  const savingsBaseToken = USD_MOCK_TOKEN.clone({
-    symbol: variant === 'dai' ? TokenSymbol('DAI') : TokenSymbol('USDS'),
-  })
   const savingsType = variant === 'dai' ? 'sdai' : 'susds'
 
   return (
@@ -70,28 +67,12 @@ export function SavingsTokenPanel({
           </Button>
         </div>
       </div>
-      <div className="flex flex-col items-center gap-1 sm:gap-2">
-        <div className="flex flex-row items-center gap-1.5 md:gap-3">
-          <img src={getTokenImage(savingsBaseToken.symbol)} className="h-5 md:h-8" />
-          <div
-            className="flex flex-row items-end justify-center slashed-zero tabular-nums"
-            data-testid={testIds.savings.sDaiBalanceInDai}
-          >
-            <div className="font-semibold text-3xl md:text-5xl">{getWholePart(depositedUSD)}</div>
-            {depositedUSDPrecision > 0 && (
-              <div className="font-semibold text-lg md:text-2xl">
-                {getFractionalPart(depositedUSD, depositedUSDPrecision)}
-              </div>
-            )}
-          </div>
-        </div>
-        <div className="font-semibold text-basics-dark-grey text-xs tracking-wide">
-          =
-          <span data-testid={testIds.savings.sDaiBalance}>
-            {tokenWithBalance.token.format(tokenWithBalance.balance, { style: 'auto' })} {tokenWithBalance.token.symbol}
-          </span>
-        </div>
-      </div>
+      <GrowingBalance
+        savingsTokenWithBalance={savingsTokenWithBalance}
+        assetsToken={assetsToken}
+        calculateSavingsBalance={calculateSavingsBalance}
+        balanceRefreshIntervalInMs={balanceRefreshIntervalInMs}
+      />
       <div className="flex flex-row items-end justify-between border-t pt-6">
         <SavingsInfoTile>
           <SavingsInfoTile.Label tooltipContent="This is an estimate of what you could earn in 30 days.">
@@ -100,11 +81,11 @@ export function SavingsTokenPanel({
           </SavingsInfoTile.Label>
           <SavingsInfoTile.Value color="green">
             +
-            {savingsBaseToken.formatUSD(currentProjections.thirtyDays, {
+            {assetsToken.formatUSD(currentProjections.thirtyDays, {
               showCents: 'when-not-round',
               compact: compactProjections,
             })}{' '}
-            {savingsBaseToken.symbol}
+            {assetsToken.symbol}
           </SavingsInfoTile.Value>
         </SavingsInfoTile>
         <SavingsInfoTile>
@@ -114,11 +95,11 @@ export function SavingsTokenPanel({
           </SavingsInfoTile.Label>
           <SavingsInfoTile.Value color="green">
             +
-            {savingsBaseToken.formatUSD(currentProjections.oneYear, {
+            {assetsToken.formatUSD(currentProjections.oneYear, {
               showCents: 'when-not-round',
               compact: compactProjections,
             })}{' '}
-            {savingsBaseToken.symbol}
+            {assetsToken.symbol}
           </SavingsInfoTile.Value>
         </SavingsInfoTile>
         <SavingsInfoTile>

--- a/packages/app/src/features/savings/logic/makeSavingsOverview.ts
+++ b/packages/app/src/features/savings/logic/makeSavingsOverview.ts
@@ -3,62 +3,58 @@ import { SavingsInfo } from '@/domain/savings-info/types'
 import { NormalizedUnitNumber } from '@/domain/types/NumericValues'
 
 const DEFAULT_PRECISION = 6
+export const STEP_IN_MS = 50
 
 export interface MakeSavingsOverviewParams {
   savingsTokenWithBalance: TokenWithBalance
   savingsInfo: SavingsInfo
   timestampInMs: number
-  stepInMs: number
 }
 export interface SavingsOverview {
-  depositedUSD: NormalizedUnitNumber
-  depositedUSDPrecision: number
+  depositedAssets: NormalizedUnitNumber
+  depositedAssetsPrecision: number
 }
 
 export function makeSavingsOverview({
   savingsTokenWithBalance,
   savingsInfo,
   timestampInMs,
-  stepInMs,
 }: MakeSavingsOverviewParams): SavingsOverview {
-  const [depositedUSD, precision] = calculateSharesToDaiWithPrecision({
+  const [assets, precision] = convertSharesToAssetsWithPrecision({
     shares: savingsTokenWithBalance.balance,
     savingsInfo,
     timestampInMs,
-    stepInMs,
   })
 
   return {
-    depositedUSD,
-    depositedUSDPrecision: precision,
+    depositedAssets: assets,
+    depositedAssetsPrecision: precision,
   }
 }
 
-interface CalculateSharesToDaiWithPrecisionParams {
+interface ConvertSharesToAssetsWithPrecisionParams {
   shares: NormalizedUnitNumber
   savingsInfo: SavingsInfo
   timestampInMs: number
-  stepInMs: number
 }
-function calculateSharesToDaiWithPrecision({
+function convertSharesToAssetsWithPrecision({
   shares,
   savingsInfo,
   timestampInMs,
-  stepInMs,
-}: CalculateSharesToDaiWithPrecisionParams): [NormalizedUnitNumber, number] {
+}: ConvertSharesToAssetsWithPrecisionParams): [NormalizedUnitNumber, number] {
   if (!savingsInfo.supportsRealTimeInterestAccrual) {
     return [savingsInfo.convertToAssets({ shares }), DEFAULT_PRECISION]
   }
 
   const current = interpolateSharesToAssets({ shares, savingsInfo, timestampInMs })
-  const next = interpolateSharesToAssets({ shares, savingsInfo, timestampInMs: timestampInMs + stepInMs })
+  const next = interpolateSharesToAssets({ shares, savingsInfo, timestampInMs: timestampInMs + STEP_IN_MS })
 
   const precision = calculatePrecision({ current, next })
 
   return [current, precision]
 }
 
-interface InterpolateSharesToDaiParams {
+interface InterpolateSharesToAssetsParams {
   shares: NormalizedUnitNumber
   savingsInfo: SavingsInfo
   timestampInMs: number
@@ -68,7 +64,7 @@ function interpolateSharesToAssets({
   shares,
   savingsInfo,
   timestampInMs,
-}: InterpolateSharesToDaiParams): NormalizedUnitNumber {
+}: InterpolateSharesToAssetsParams): NormalizedUnitNumber {
   const timestamp = Math.floor(timestampInMs / 1000)
 
   const now = savingsInfo.predictAssetsAmount({ timestamp, shares })

--- a/packages/app/src/features/savings/logic/useSavings.ts
+++ b/packages/app/src/features/savings/logic/useSavings.ts
@@ -21,17 +21,17 @@ import { useMemo } from 'react'
 import { Projections } from '../types'
 import { MigrationInfo, makeMigrationInfo } from './makeMigrationInfo'
 import { SavingsMeta, makeSavingsMeta } from './makeSavingsMeta'
+import { SavingsOverview } from './makeSavingsOverview'
 import { makeSavingsTokenDetails } from './makeSavingsTokenDetails'
 import { useWelcomeDialog } from './useWelcomeDialog'
 
-const stepInMs = 50
-
 export interface SavingsTokenDetails {
   APY: Percentage
-  tokenWithBalance: TokenWithBalance
   currentProjections: Projections
-  depositedUSD: NormalizedUnitNumber
-  depositedUSDPrecision: number
+  savingsTokenWithBalance: TokenWithBalance
+  assetsToken: Token
+  calculateSavingsBalance: (timestampInMs: number) => SavingsOverview
+  balanceRefreshIntervalInMs: number | undefined
 }
 
 export interface AssetInWallet {
@@ -66,9 +66,7 @@ export function useSavings(): UseSavingsResults {
   const { inputTokens, sdaiWithBalance, susdsWithBalance } = useSavingsTokens({ chainId })
   const { originChainId, extraTokens } = getChainConfigEntry(chainId)
   const { tokensInfo } = useTokensInfo({ tokens: extraTokens, chainId })
-  const { timestamp, timestampInMs } = useTimestamp({
-    refreshIntervalInMs: (savingsDaiInfo ?? savingsUsdsInfo)?.supportsRealTimeInterestAccrual ? stepInMs : undefined,
-  })
+  const { timestamp } = useTimestamp()
   const openDialog = useOpenDialog()
   const { showWelcomeDialog, saveConfirmedWelcomeDialog } = useWelcomeDialog({
     chainId,
@@ -89,17 +87,15 @@ export function useSavings(): UseSavingsResults {
   const sDaiDetails = makeSavingsTokenDetails({
     savingsInfo: savingsDaiInfo,
     savingsTokenWithBalance: sdaiWithBalance,
+    assetsToken: tokensInfo.DAI,
     timestamp,
-    timestampInMs,
-    stepInMs,
   })
 
   const sUSDSDetails = makeSavingsTokenDetails({
     savingsInfo: savingsUsdsInfo,
     savingsTokenWithBalance: susdsWithBalance,
+    assetsToken: tokensInfo.USDS,
     timestamp,
-    timestampInMs,
-    stepInMs,
   })
 
   // biome-ignore lint/correctness/useExhaustiveDependencies:

--- a/packages/app/src/features/savings/views/GuestView.stories.ts
+++ b/packages/app/src/features/savings/views/GuestView.stories.ts
@@ -8,6 +8,7 @@ import { tokens } from '@storybook/tokens'
 import { getMobileStory, getTabletStory } from '@storybook/viewports'
 import { mainnet } from 'viem/chains'
 import { mockDsrChartData, mockSsrChartData } from '../components/savings-charts/fixtures/mockSavingsRateChartData'
+import { SavingsTokenDetails } from '../logic/useSavings'
 import { GuestView } from './GuestView'
 
 const myEarningsInfo = {
@@ -43,14 +44,18 @@ const savingsChartsInfo = {
 
 const savingsTokenDetails = {
   APY: Percentage(0.065),
-  tokenWithBalance: { balance: NormalizedUnitNumber(20_000), token: tokens.sUSDS },
+  savingsTokenWithBalance: { balance: NormalizedUnitNumber(20_000), token: tokens.sUSDS },
+  assetsToken: tokens.USDS,
+  balanceRefreshIntervalInMs: 50,
   currentProjections: {
     thirtyDays: NormalizedUnitNumber(500),
     oneYear: NormalizedUnitNumber(2500),
   },
-  depositedUSD: NormalizedUnitNumber(20765.7654),
-  depositedUSDPrecision: 2,
-}
+  calculateSavingsBalance: () => ({
+    depositedAssets: NormalizedUnitNumber(20765.7654),
+    depositedAssetsPrecision: 2,
+  }),
+} satisfies SavingsTokenDetails
 
 const meta: Meta<typeof GuestView> = {
   title: 'Features/Savings/Views/GuestView',

--- a/packages/app/src/features/savings/views/GuestView.tsx
+++ b/packages/app/src/features/savings/views/GuestView.tsx
@@ -34,7 +34,7 @@ export function GuestView({
   const { susdsSymbol } = getChainConfigEntry(originChainId)
 
   const Charts =
-    savingsTokenDetails.tokenWithBalance.token.symbol === susdsSymbol ? UsdsSavingsCharts : DaiSavingsCharts
+    savingsTokenDetails.savingsTokenWithBalance.token.symbol === susdsSymbol ? UsdsSavingsCharts : DaiSavingsCharts
 
   return (
     <PageLayout>

--- a/packages/app/src/features/savings/views/SavingsDaiAndUSDSView.stories.ts
+++ b/packages/app/src/features/savings/views/SavingsDaiAndUSDSView.stories.ts
@@ -12,6 +12,7 @@ import {
   mockEarningsPredictionsChartData,
 } from '../components/savings-charts/fixtures/mockEarningsChartData'
 import { mockDsrChartData, mockSsrChartData } from '../components/savings-charts/fixtures/mockSavingsRateChartData'
+import { SavingsTokenDetails } from '../logic/useSavings'
 import { SavingsDaiAndUsdsView } from './SavingsDaiAndUSDSView'
 
 const myEarningsInfo = {
@@ -98,25 +99,30 @@ const savingsViewBaseArgs = {
 
 const sUSDSDetails = {
   APY: Percentage(0.05),
-  tokenWithBalance: { balance: NormalizedUnitNumber(10_000), token: tokens.sUSDS },
+  savingsTokenWithBalance: { balance: NormalizedUnitNumber(10_000), token: tokens.sUSDS },
+  assetsToken: tokens.USDS,
+  balanceRefreshIntervalInMs: 50,
   currentProjections: {
     thirtyDays: NormalizedUnitNumber(250),
     oneYear: NormalizedUnitNumber(1250),
   },
-  depositedUSD: NormalizedUnitNumber(10365.7654),
-  depositedUSDPrecision: 2,
-}
+  calculateSavingsBalance: () => ({
+    depositedAssets: NormalizedUnitNumber(10365.7654),
+    depositedAssetsPrecision: 2,
+  }),
+} satisfies SavingsTokenDetails
 
 const sDaiDetails = {
   APY: Percentage(0.05),
-  tokenWithBalance: { balance: NormalizedUnitNumber(20_000), token: tokens.sDAI },
+  savingsTokenWithBalance: { balance: NormalizedUnitNumber(20_000), token: tokens.sDAI },
+  assetsToken: tokens.DAI,
+  balanceRefreshIntervalInMs: 50,
   currentProjections: {
     thirtyDays: NormalizedUnitNumber(500),
     oneYear: NormalizedUnitNumber(2500),
   },
-  depositedUSD: NormalizedUnitNumber(20765.7654),
-  depositedUSDPrecision: 2,
-}
+  calculateSavingsBalance: () => ({ depositedAssets: NormalizedUnitNumber(20765.7654), depositedAssetsPrecision: 2 }),
+} satisfies SavingsTokenDetails
 
 const meta: Meta<typeof SavingsDaiAndUsdsView> = {
   title: 'Features/Savings/Views/SavingsDaiAndUsdsView',
@@ -147,21 +153,21 @@ export const NoDeposit: Story = {
     },
     sDaiDetails: {
       ...sDaiDetails,
-      tokenWithBalance: { balance: NormalizedUnitNumber(0), token: tokens.sDAI },
+      savingsTokenWithBalance: { balance: NormalizedUnitNumber(0), token: tokens.sDAI },
       currentProjections: {
         thirtyDays: NormalizedUnitNumber(0),
         oneYear: NormalizedUnitNumber(0),
       },
-      depositedUSD: NormalizedUnitNumber(0),
+      calculateSavingsBalance: () => ({ depositedAssets: NormalizedUnitNumber(0), depositedAssetsPrecision: 2 }),
     },
     sUSDSDetails: {
       ...sUSDSDetails,
-      tokenWithBalance: { balance: NormalizedUnitNumber(0), token: tokens.sUSDS },
+      savingsTokenWithBalance: { balance: NormalizedUnitNumber(0), token: tokens.sUSDS },
       currentProjections: {
         thirtyDays: NormalizedUnitNumber(0),
         oneYear: NormalizedUnitNumber(0),
       },
-      depositedUSD: NormalizedUnitNumber(0),
+      calculateSavingsBalance: () => ({ depositedAssets: NormalizedUnitNumber(0), depositedAssetsPrecision: 2 }),
     },
   },
 }
@@ -174,12 +180,12 @@ export const OnlySavingsDaiBalance: Story = {
     totalEligibleCashUSD: NormalizedUnitNumber(0),
     sUSDSDetails: {
       ...sUSDSDetails,
-      tokenWithBalance: { balance: NormalizedUnitNumber(0), token: tokens.sUSDS },
+      savingsTokenWithBalance: { balance: NormalizedUnitNumber(0), token: tokens.sUSDS },
       currentProjections: {
         thirtyDays: NormalizedUnitNumber(0),
         oneYear: NormalizedUnitNumber(0),
       },
-      depositedUSD: NormalizedUnitNumber(0),
+      calculateSavingsBalance: () => ({ depositedAssets: NormalizedUnitNumber(0), depositedAssetsPrecision: 2 }),
     },
     sDaiDetails,
     assetsInWallet: [
@@ -211,12 +217,12 @@ export const OnlySavingsUsdsBalance: Story = {
     sUSDSDetails,
     sDaiDetails: {
       ...sDaiDetails,
-      tokenWithBalance: { balance: NormalizedUnitNumber(0), token: tokens.sDAI },
+      savingsTokenWithBalance: { balance: NormalizedUnitNumber(0), token: tokens.sDAI },
       currentProjections: {
         thirtyDays: NormalizedUnitNumber(0),
         oneYear: NormalizedUnitNumber(0),
       },
-      depositedUSD: NormalizedUnitNumber(0),
+      calculateSavingsBalance: () => ({ depositedAssets: NormalizedUnitNumber(0), depositedAssetsPrecision: 2 }),
     },
     assetsInWallet: [
       {
@@ -283,21 +289,21 @@ export const NoDepositNoCash: Story = {
     totalEligibleCashUSD: NormalizedUnitNumber(0),
     sDaiDetails: {
       ...sDaiDetails,
-      tokenWithBalance: { balance: NormalizedUnitNumber(0), token: tokens.sDAI },
+      savingsTokenWithBalance: { balance: NormalizedUnitNumber(0), token: tokens.sDAI },
       currentProjections: {
         thirtyDays: NormalizedUnitNumber(0),
         oneYear: NormalizedUnitNumber(0),
       },
-      depositedUSD: NormalizedUnitNumber(0),
+      calculateSavingsBalance: () => ({ depositedAssets: NormalizedUnitNumber(0), depositedAssetsPrecision: 2 }),
     },
     sUSDSDetails: {
       ...sUSDSDetails,
-      tokenWithBalance: { balance: NormalizedUnitNumber(0), token: tokens.sUSDS },
+      savingsTokenWithBalance: { balance: NormalizedUnitNumber(0), token: tokens.sUSDS },
       currentProjections: {
         thirtyDays: NormalizedUnitNumber(0),
         oneYear: NormalizedUnitNumber(0),
       },
-      depositedUSD: NormalizedUnitNumber(0),
+      calculateSavingsBalance: () => ({ depositedAssets: NormalizedUnitNumber(0), depositedAssetsPrecision: 2 }),
     },
     assetsInWallet: [
       {
@@ -327,23 +333,31 @@ export const BigNumbersDesktop: Story = {
     ...savingsViewBaseArgs,
     sDaiDetails: {
       APY: Percentage(0.05),
-      tokenWithBalance: { balance: NormalizedUnitNumber(134000000.0), token: tokens.sDAI },
+      assetsToken: tokens.DAI,
+      balanceRefreshIntervalInMs: 50,
+      savingsTokenWithBalance: { balance: NormalizedUnitNumber(134000000.0), token: tokens.sDAI },
       currentProjections: {
         thirtyDays: NormalizedUnitNumber(1224300.923423423),
         oneYear: NormalizedUnitNumber(6345543.32945601),
       },
-      depositedUSD: NormalizedUnitNumber('134395765.123482934245'),
-      depositedUSDPrecision: 0,
+      calculateSavingsBalance: () => ({
+        depositedAssets: NormalizedUnitNumber('134395765.123482934245'),
+        depositedAssetsPrecision: 0,
+      }),
     },
     sUSDSDetails: {
       APY: Percentage(0.05),
-      tokenWithBalance: { balance: NormalizedUnitNumber(134000000.0), token: tokens.sUSDS },
+      savingsTokenWithBalance: { balance: NormalizedUnitNumber(134000000.0), token: tokens.sUSDS },
+      assetsToken: tokens.USDS,
+      balanceRefreshIntervalInMs: 50,
       currentProjections: {
         thirtyDays: NormalizedUnitNumber(1224300.923423423),
         oneYear: NormalizedUnitNumber(6345543.32945601),
       },
-      depositedUSD: NormalizedUnitNumber('134395765.123482934245'),
-      depositedUSDPrecision: 0,
+      calculateSavingsBalance: () => ({
+        depositedAssets: NormalizedUnitNumber('134395765.123482934245'),
+        depositedAssetsPrecision: 0,
+      }),
     },
 
     assetsInWallet: [
@@ -374,12 +388,12 @@ export const DepositSavingDaiOnlyChartsUnsupported: Story = {
     totalEligibleCashUSD: NormalizedUnitNumber(12345),
     sUSDSDetails: {
       ...sUSDSDetails,
-      tokenWithBalance: { balance: NormalizedUnitNumber(0), token: tokens.sUSDS },
+      savingsTokenWithBalance: { balance: NormalizedUnitNumber(0), token: tokens.sUSDS },
       currentProjections: {
         thirtyDays: NormalizedUnitNumber(0),
         oneYear: NormalizedUnitNumber(0),
       },
-      depositedUSD: NormalizedUnitNumber(0),
+      calculateSavingsBalance: () => ({ depositedAssets: NormalizedUnitNumber(0), depositedAssetsPrecision: 2 }),
     },
     sDaiDetails,
     assetsInWallet: [

--- a/packages/app/src/features/savings/views/SavingsDaiAndUSDSView.tsx
+++ b/packages/app/src/features/savings/views/SavingsDaiAndUSDSView.tsx
@@ -35,8 +35,8 @@ export function SavingsDaiAndUsdsView({
   saveConfirmedWelcomeDialog,
   savingsChartsInfo,
 }: SavingsDaiAndUsdsViewProps) {
-  const displaySavingsDai = sDaiDetails.tokenWithBalance.balance.gt(0)
-  const displaySavingsUsds = sUSDSDetails.tokenWithBalance.balance.gt(0)
+  const displaySavingsDai = sDaiDetails.savingsTokenWithBalance.balance.gt(0)
+  const displaySavingsUsds = sUSDSDetails.savingsTokenWithBalance.balance.gt(0)
 
   const displaySavingsOpportunity =
     (!displaySavingsDai && !displaySavingsUsds) ||

--- a/packages/app/src/features/savings/views/SavingsDaiView.stories.ts
+++ b/packages/app/src/features/savings/views/SavingsDaiView.stories.ts
@@ -12,6 +12,7 @@ import {
   mockEarningsPredictionsChartData,
 } from '../components/savings-charts/fixtures/mockEarningsChartData'
 import { mockDsrChartData, mockSsrChartData } from '../components/savings-charts/fixtures/mockSavingsRateChartData'
+import { SavingsTokenDetails } from '../logic/useSavings'
 import { SavingsDaiView } from './SavingsDaiView'
 
 const myEarningsInfo = {
@@ -79,14 +80,15 @@ const savingsViewBaseArgs = {
 
 const savingsTokenDetails = {
   APY: Percentage(0.05),
-  tokenWithBalance: { balance: NormalizedUnitNumber(20_000), token: tokens.sDAI },
+  savingsTokenWithBalance: { balance: NormalizedUnitNumber(20_000), token: tokens.sDAI },
+  assetsToken: tokens.DAI,
+  balanceRefreshIntervalInMs: 50,
   currentProjections: {
     thirtyDays: NormalizedUnitNumber(500),
     oneYear: NormalizedUnitNumber(2500),
   },
-  depositedUSD: NormalizedUnitNumber(20765.7654),
-  depositedUSDPrecision: 2,
-}
+  calculateSavingsBalance: () => ({ depositedAssets: NormalizedUnitNumber(20765.7654), depositedAssetsPrecision: 2 }),
+} satisfies SavingsTokenDetails
 
 const meta: Meta<typeof SavingsDaiView> = {
   title: 'Features/Savings/Views/SavingsDaiView',
@@ -117,12 +119,12 @@ export const NoDeposit: Story = {
     },
     savingsTokenDetails: {
       ...savingsTokenDetails,
-      tokenWithBalance: { balance: NormalizedUnitNumber(0), token: tokens.sDAI },
+      savingsTokenWithBalance: { balance: NormalizedUnitNumber(0), token: tokens.sDAI },
       currentProjections: {
         thirtyDays: NormalizedUnitNumber(0),
         oneYear: NormalizedUnitNumber(0),
       },
-      depositedUSD: NormalizedUnitNumber(0),
+      calculateSavingsBalance: () => ({ depositedAssets: NormalizedUnitNumber(0), depositedAssetsPrecision: 2 }),
     },
   },
 }
@@ -171,12 +173,12 @@ export const NoDepositNoCash: Story = {
 
     savingsTokenDetails: {
       ...savingsTokenDetails,
-      tokenWithBalance: { balance: NormalizedUnitNumber(0), token: tokens.sDAI },
+      savingsTokenWithBalance: { balance: NormalizedUnitNumber(0), token: tokens.sDAI },
       currentProjections: {
         thirtyDays: NormalizedUnitNumber(0),
         oneYear: NormalizedUnitNumber(0),
       },
-      depositedUSD: NormalizedUnitNumber(0),
+      calculateSavingsBalance: () => ({ depositedAssets: NormalizedUnitNumber(0), depositedAssetsPrecision: 2 }),
     },
     assetsInWallet: [
       {
@@ -207,13 +209,17 @@ export const BigNumbersDesktop: Story = {
 
     savingsTokenDetails: {
       APY: Percentage(0.05),
-      tokenWithBalance: { balance: NormalizedUnitNumber(134000000.0), token: tokens.sDAI },
+      savingsTokenWithBalance: { balance: NormalizedUnitNumber(134000000.0), token: tokens.sDAI },
+      assetsToken: tokens.DAI,
+      balanceRefreshIntervalInMs: 50,
       currentProjections: {
         thirtyDays: NormalizedUnitNumber(1224300.923423423),
         oneYear: NormalizedUnitNumber(6345543.32945601),
       },
-      depositedUSD: NormalizedUnitNumber('134395765.123482934245'),
-      depositedUSDPrecision: 0,
+      calculateSavingsBalance: () => ({
+        depositedAssets: NormalizedUnitNumber('134395765.123482934245'),
+        depositedAssetsPrecision: 0,
+      }),
     },
     assetsInWallet: [
       {

--- a/packages/app/src/features/savings/views/SavingsDaiView.tsx
+++ b/packages/app/src/features/savings/views/SavingsDaiView.tsx
@@ -19,7 +19,7 @@ export function SavingsDaiView({
   openDialog,
   savingsChartsInfo,
 }: SavingsViewContentProps) {
-  const displaySavingsDai = savingsTokenDetails.tokenWithBalance.balance.gt(0)
+  const displaySavingsDai = savingsTokenDetails.savingsTokenWithBalance.balance.gt(0)
 
   const displaySavingsDaiChart = savingsChartsInfo.chartsSupported
   const displaySavingsOpportunity = !displaySavingsDai || !displaySavingsDaiChart

--- a/packages/app/src/features/savings/views/SavingsUSDSView.stories.ts
+++ b/packages/app/src/features/savings/views/SavingsUSDSView.stories.ts
@@ -12,6 +12,7 @@ import {
   mockEarningsPredictionsChartData,
 } from '../components/savings-charts/fixtures/mockEarningsChartData'
 import { mockDsrChartData, mockSsrChartData } from '../components/savings-charts/fixtures/mockSavingsRateChartData'
+import { SavingsTokenDetails } from '../logic/useSavings'
 import { SavingsUsdsView } from './SavingsUSDSView'
 
 const myEarningsInfo = {
@@ -78,14 +79,15 @@ const savingsViewBaseArgs = {
 
 const savingsTokenDetails = {
   APY: Percentage(0.05),
-  tokenWithBalance: { balance: NormalizedUnitNumber(10_000), token: tokens.sUSDS },
+  savingsTokenWithBalance: { balance: NormalizedUnitNumber(10_000), token: tokens.sUSDS },
+  assetsToken: tokens.USDS,
+  balanceRefreshIntervalInMs: 50,
   currentProjections: {
     thirtyDays: NormalizedUnitNumber(250),
     oneYear: NormalizedUnitNumber(1250),
   },
-  depositedUSD: NormalizedUnitNumber(10365.7654),
-  depositedUSDPrecision: 2,
-}
+  calculateSavingsBalance: () => ({ depositedAssets: NormalizedUnitNumber(10365.7654), depositedAssetsPrecision: 2 }),
+} satisfies SavingsTokenDetails
 
 const meta: Meta<typeof SavingsUsdsView> = {
   title: 'Features/Savings/Views/SavingsUsdsView',
@@ -145,12 +147,12 @@ export const NoDeposit: Story = {
     },
     savingsTokenDetails: {
       ...savingsTokenDetails,
-      tokenWithBalance: { balance: NormalizedUnitNumber(0), token: tokens.sUSDS },
+      savingsTokenWithBalance: { balance: NormalizedUnitNumber(0), token: tokens.sUSDS },
       currentProjections: {
         thirtyDays: NormalizedUnitNumber(0),
         oneYear: NormalizedUnitNumber(0),
       },
-      depositedUSD: NormalizedUnitNumber(0),
+      calculateSavingsBalance: () => ({ depositedAssets: NormalizedUnitNumber(0), depositedAssetsPrecision: 2 }),
     },
   },
 }
@@ -171,12 +173,12 @@ export const NoDepositNoCash: Story = {
     totalEligibleCashUSD: NormalizedUnitNumber(0),
     savingsTokenDetails: {
       ...savingsTokenDetails,
-      tokenWithBalance: { balance: NormalizedUnitNumber(0), token: tokens.sUSDS },
+      savingsTokenWithBalance: { balance: NormalizedUnitNumber(0), token: tokens.sUSDS },
       currentProjections: {
         thirtyDays: NormalizedUnitNumber(0),
         oneYear: NormalizedUnitNumber(0),
       },
-      depositedUSD: NormalizedUnitNumber(0),
+      calculateSavingsBalance: () => ({ depositedAssets: NormalizedUnitNumber(0), depositedAssetsPrecision: 2 }),
     },
 
     assetsInWallet: [
@@ -207,13 +209,17 @@ export const BigNumbersDesktop: Story = {
     ...savingsViewBaseArgs,
     savingsTokenDetails: {
       APY: Percentage(0.05),
-      tokenWithBalance: { balance: NormalizedUnitNumber(134000000.0), token: tokens.sUSDS },
+      savingsTokenWithBalance: { balance: NormalizedUnitNumber(134000000.0), token: tokens.sUSDS },
+      assetsToken: tokens.USDS,
+      balanceRefreshIntervalInMs: 50,
       currentProjections: {
         thirtyDays: NormalizedUnitNumber(1224300.923423423),
         oneYear: NormalizedUnitNumber(6345543.32945601),
       },
-      depositedUSD: NormalizedUnitNumber('134395765.123482934245'),
-      depositedUSDPrecision: 0,
+      calculateSavingsBalance: () => ({
+        depositedAssets: NormalizedUnitNumber('134395765.123482934245'),
+        depositedAssetsPrecision: 0,
+      }),
     },
 
     assetsInWallet: [

--- a/packages/app/src/features/savings/views/SavingsUSDSView.tsx
+++ b/packages/app/src/features/savings/views/SavingsUSDSView.tsx
@@ -18,7 +18,7 @@ export function SavingsUsdsView({
   savingsMeta,
   savingsChartsInfo,
 }: SavingsViewContentProps) {
-  const displaySavingsUsds = savingsTokenDetails.tokenWithBalance.balance.gt(0)
+  const displaySavingsUsds = savingsTokenDetails.savingsTokenWithBalance.balance.gt(0)
 
   const displaySavingsUsdsChart = savingsChartsInfo.chartsSupported
   const displaySavingsOpportunity = !displaySavingsUsds || !displaySavingsUsdsChart


### PR DESCRIPTION
Closes FRO-1033

Note: I've updated storybook dai price to be exactly `1` (so it matches our app reality). There is a lot of changes in stories because of that, but they are only cosmetic ones, where usd formatted value was displayed.