### PR TITLE
Refactor tailwind config colors

### DIFF
--- a/packages/app/src/features/savings/components/navbar-item/SavingsAPYBadge.tsx
+++ b/packages/app/src/features/savings/components/navbar-item/SavingsAPYBadge.tsx
@@ -9,12 +9,12 @@ export interface SavingsAPYBadgeProps {
 
 export function SavingsAPYBadge({ APY, isLoading }: SavingsAPYBadgeProps) {
   return (
-    <div className="inline-flex h-5 min-w-8 items-center justify-center rounded-md bg-savings-gradient px-1.5">
+    <div className="inline-flex h-5 min-w-8 items-center justify-center rounded-md bg-gradient-savings px-1.5">
       {isLoading ? (
-        <Skeleton className="h-4 w-5 rounded-sm bg-reskin-base-white/80 backdrop-brightness-75" />
+        <Skeleton className="h-4 w-5 rounded-sm bg-primary/80 backdrop-brightness-75" />
       ) : (
         APY && (
-          <span className="typography-label-5 text-reskin-base-white">
+          <span className="typography-label-5 text-primary-inverse">
             {formatPercentage(APY, { minimumFractionDigits: 0 })}
           </span>
         )

--- a/packages/app/src/ui/atoms/dropdown/DropdownMenu.tsx
+++ b/packages/app/src/ui/atoms/dropdown/DropdownMenu.tsx
@@ -25,7 +25,8 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[state=open]:bg-accent focus:bg-accent',
+      'flex cursor-default select-none items-center rounded-sm px-2 py-1.5',
+      'text-sm outline-none data-[state=open]:bg-accent focus:bg-accent',
       inset && 'pl-8',
       className,
     )}
@@ -44,7 +45,13 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=closed]:animate-out data-[state=open]:animate-in',
+      'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+      'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2',
+      'data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1',
+      'text-popover-foreground shadow-lg data-[state=closed]:animate-out',
+      'data-[state=open]:animate-in',
       className,
     )}
     {...props}
@@ -61,7 +68,13 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border border-reskin-border-primary bg-reskin-bg-primary text-primary shadow-md data-[state=closed]:animate-out data-[state=open]:animate-in',
+        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+        'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+        'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2',
+        'data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'z-50 min-w-[8rem] overflow-hidden rounded-md border border-primary',
+        'bg-primary text-primary shadow-md data-[state=closed]:animate-out',
+        'data-[state=open]:animate-in',
         className,
       )}
       {...props}
@@ -77,7 +90,11 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      'typography-label-4 relative flex cursor-default select-none items-center border-b border-b-reskin-border-primary p-4 text-primary outline-none transition-colors data-[disabled]:pointer-events-none first:rounded-t-xs last:rounded-b-xs last:border-none focus:bg-reskin-bg-secondary data-[disabled]:opacity-50',
+      'typography-label-4 relative flex cursor-default select-none items-center',
+      'border-b border-b-primary p-4 text-primary outline-none',
+      'transition-colors data-[disabled]:pointer-events-none first:rounded-t-xs',
+      'last:rounded-b-xs last:border-none focus:bg-secondary',
+      'data-[disabled]:opacity-50',
       className,
     )}
     {...props}
@@ -92,7 +109,10 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-none transition-colors data-[disabled]:pointer-events-none focus:bg-accent focus:text-accent-foreground data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center rounded-sm',
+      'py-1.5 pr-2 pl-8 text-sm outline-none transition-color',
+      'data-[disabled]:pointer-events-none focus:bg-accent',
+      'focus:text-accent-foreground data-[disabled]:opacity-50',
       className,
     )}
     checked={checked}
@@ -115,7 +135,10 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-none transition-colors data-[disabled]:pointer-events-none focus:bg-accent focus:text-accent-foreground data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center rounded-sm',
+      'py-1.5 pr-2 pl-8 text-sm outline-none transition-colors',
+      'data-[disabled]:pointer-events-none focus:bg-accent',
+      'focus:text-accent-foreground data-[disabled]:opacity-50',
       className,
     )}
     {...props}
@@ -142,7 +165,7 @@ const DropdownMenuSeparator = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
 >(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.Separator ref={ref} className={cn('-mx-1 h-px bg-reskin-bg-primary', className)} {...props} />
+  <DropdownMenuPrimitive.Separator ref={ref} className={cn('-mx-1 h-px bg-primary', className)} {...props} />
 ))
 DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
 

--- a/packages/app/src/ui/atoms/new/button/Button.tsx
+++ b/packages/app/src/ui/atoms/new/button/Button.tsx
@@ -25,7 +25,7 @@ const buttonVariants = cva(
           'hover:bg-reskin-neutral-800 active:text-reskin-base-white',
         ),
         tertiary: cn(
-          'border border-reskin-border-primary border-solid bg-reskin-base-white',
+          'border border-primary border-solid bg-reskin-base-white',
           'text-reskin-neutral-950 shadow-xs active:bg-reskin-neutral-100 hover:bg-reskin-neutral-50',
         ),
         loading: 'cursor-wait bg-reskin-neutral-50 text-reskin-base-white',

--- a/packages/app/src/ui/atoms/new/close-button/CloseButton.tsx
+++ b/packages/app/src/ui/atoms/new/close-button/CloseButton.tsx
@@ -13,7 +13,7 @@ export const CloseButton = forwardRef<HTMLButtonElement, CloseButtonProps>(({ on
       'rounded-sm p-2 text-secondary transition-colors',
       'hover:text-reskin-neutral-700',
       'active:text-reskin-neutral-900',
-      'focus-visible:outline-none focus-visible:ring focus-visible:ring-reskin-border-focus',
+      'focus-visible:outline-none focus-visible:ring focus-visible:ring-reskin-primary-200',
       'disabled:cursor-not-allowed disabled:text-reskin-neutral-300',
     )}
     onClick={onClose}

--- a/packages/app/src/ui/atoms/new/icon-box/IconBox.tsx
+++ b/packages/app/src/ui/atoms/new/icon-box/IconBox.tsx
@@ -43,7 +43,7 @@ export const iconBoxVariants = cva('inline-flex items-center justify-center roun
     variant: {
       success: 'bg-reskin-fg-system-success-secondary text-white',
       warning: 'bg-reskin-fg-system-warning-primary text-white',
-      info: 'bg-reskin-border-focus text-brand',
+      info: 'bg-brand-secondary text-brand',
       error: 'bg-reskin-fg-system-error-secondary text-white',
     },
     size: {

--- a/packages/app/src/ui/atoms/new/select/Select.tsx
+++ b/packages/app/src/ui/atoms/new/select/Select.tsx
@@ -16,12 +16,12 @@ const SelectTrigger = React.forwardRef<
     ref={ref}
     className={cn(
       'group flex w-full items-center justify-between',
-      'rounded-sm border border-reskin-border-primary bg-reskin-bg-primary text-reskin-fg-primary',
+      'rounded-sm border border-primary bg-primary text-reskin-fg-primary',
       'p-3 ring-offset-background placeholder:text-muted-foreground',
-      'hover:border-reskin-border-tertiary hover:shadow-sm',
-      'disabled:cursor-not-allowed disabled:border-reskin-border-secondary disabled:opacity-50 disabled:shadow-xs ',
+      'hover:border-tertiary hover:shadow-sm',
+      'disabled:cursor-not-allowed disabled:border-secondary disabled:opacity-50 disabled:shadow-xs ',
       'focus-visible:outline-none focus-visible:ring focus-visible:ring-reskin-primary-200 focus-visible:ring-offset-0',
-      'data-[state=open]:border-reskin-border-secondary data-[state=open]:shadow-sm',
+      'data-[state=open]:border-secondary data-[state=open]:shadow-sm',
       className,
     )}
     {...props}
@@ -43,7 +43,7 @@ const SelectContent = React.forwardRef<
       ref={ref}
       className={cn(
         'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=open]:animate-in',
-        'relative z-50 min-w-[8rem] overflow-hidden rounded-sm border border-reskin-border-primary bg-reskin-bg-primary text-reskin-fg-primary shadow-xl',
+        'relative z-50 min-w-[8rem] overflow-hidden rounded-sm border border-primary bg-primary text-reskin-fg-primary shadow-xl',
         position === 'popper' &&
           'data-[side=left]:-translate-x-1 data-[side=top]:-translate-y-1 data-[side=right]:translate-x-1 data-[side=bottom]:translate-y-1',
         // @note: passing max-h and overflow-y-auto is important to make scroll when there is not enough vertical space
@@ -57,7 +57,7 @@ const SelectContent = React.forwardRef<
     >
       <SelectPrimitive.Viewport
         className={cn(
-          'divide-y divide-reskin-border-primary',
+          'divide-y divide-primary',
           position === 'popper' &&
             'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]',
         )}
@@ -77,9 +77,9 @@ const SelectItem = React.forwardRef<
     ref={ref}
     className={cn(
       'relative flex w-full cursor-default select-none items-center px-3 py-4 outline-none',
-      'hover:cursor-pointer hover:bg-reskin-bg-secondary',
-      'active:bg-reskin-bg-tertiary',
-      'focus-visible:bg-reskin-bg-secondary',
+      'hover:cursor-pointer hover:bg-secondary',
+      'active:bg-tertiary',
+      'focus-visible:bg-secondary',
       'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className,
     )}

--- a/packages/app/src/ui/atoms/new/switch/Switch.tsx
+++ b/packages/app/src/ui/atoms/new/switch/Switch.tsx
@@ -11,18 +11,18 @@ const Switch = React.forwardRef<
     className={cn(
       'group padding-2 inline-flex h-5 w-9 shrink-0 items-center rounded-xss transition-all ',
       'data-[state=checked]:bg-reskin-fg-system-success-primary',
-      'data-[state=unchecked]:bg-reskin-bg-secondary',
-      'data-[state=unchecked]:ring-1 data-[state=unchecked]:ring-reskin-border-primary',
+      'data-[state=unchecked]:bg-secondary',
+      'data-[state=unchecked]:ring-1 data-[state=unchecked]:ring-primary',
       // hover
       'hover:data-[state=checked]:ring hover:data-[state=checked]:ring-[#01BF9F40]/25',
-      'hover:data-[state=unchecked]:bg-reskin-bg-tertiary hover:data-[state=unchecked]:ring-reskin-border-secondary',
+      'hover:data-[state=unchecked]:bg-tertiary hover:data-[state=unchecked]:ring-secondary',
       // active (pressed)
       'active:data-[state=checked]:bg-reskin-fg-system-success-secondary active:data-[state=checked]:ring-0',
-      'active:data-[state=unchecked]:bg-reskin-bg-primary active:data-[state=unchecked]:ring-reskin-border-primary',
+      'active:data-[state=unchecked]:bg-primary active:data-[state=unchecked]:ring-primary',
       // disabled
       'disabled:cursor-not-allowed',
       'disabled:data-[state=checked]:bg-reskin-fg-system-success-secondary/30 disabled:data-[state=checked]:ring-0',
-      'disabled:data-[state=unchecked]:bg-reskin-bg-primary disabled:data-[state=unchecked]:ring-reskin-border-primary',
+      'disabled:data-[state=unchecked]:bg-primary disabled:data-[state=unchecked]:ring-primary',
       className,
     )}
     {...props}
@@ -32,8 +32,8 @@ const Switch = React.forwardRef<
       className={cn(
         'pointer-events-none block h-4 w-4 rounded-xss',
         'transition-all data-[state=unchecked]:translate-x-[2px]',
-        'data-[state=unchecked]:bg-reskin-bg-primary-inverse',
-        'data-[state=checked]:bg-reskin-bg-primary',
+        'data-[state=unchecked]:bg-primary-inverse',
+        'data-[state=checked]:bg-primary',
         'data-[state=checked]:translate-x-[18px]',
         'data-[state=checked]:shadow-md',
         // active (pressed)

--- a/packages/app/src/ui/atoms/new/switch/Switch.tsx
+++ b/packages/app/src/ui/atoms/new/switch/Switch.tsx
@@ -12,17 +12,17 @@ const Switch = React.forwardRef<
       'group padding-2 inline-flex h-5 w-9 shrink-0 items-center rounded-xss transition-all ',
       'data-[state=checked]:bg-reskin-fg-system-success-primary',
       'data-[state=unchecked]:bg-secondary',
-      'data-[state=unchecked]:ring-1 data-[state=unchecked]:ring-primary',
+      'data-[state=unchecked]:ring-1 data-[state=unchecked]:ring-reskin-neutral-100',
       // hover
       'hover:data-[state=checked]:ring hover:data-[state=checked]:ring-[#01BF9F40]/25',
-      'hover:data-[state=unchecked]:bg-tertiary hover:data-[state=unchecked]:ring-secondary',
+      'hover:data-[state=unchecked]:bg-tertiary hover:data-[state=unchecked]:ring-reskin-neutral-200',
       // active (pressed)
       'active:data-[state=checked]:bg-reskin-fg-system-success-secondary active:data-[state=checked]:ring-0',
-      'active:data-[state=unchecked]:bg-primary active:data-[state=unchecked]:ring-primary',
+      'active:data-[state=unchecked]:bg-primary active:data-[state=unchecked]:ring-reskin-neutral-100',
       // disabled
       'disabled:cursor-not-allowed',
       'disabled:data-[state=checked]:bg-reskin-fg-system-success-secondary/30 disabled:data-[state=checked]:ring-0',
-      'disabled:data-[state=unchecked]:bg-primary disabled:data-[state=unchecked]:ring-primary',
+      'disabled:data-[state=unchecked]:bg-primary disabled:data-[state=unchecked]:ring-reskin-neutral-100',
       className,
     )}
     {...props}

--- a/packages/app/src/ui/atoms/new/tooltip/Tooltip.tsx
+++ b/packages/app/src/ui/atoms/new/tooltip/Tooltip.tsx
@@ -37,7 +37,7 @@ const Tooltip = RadixPrimitive.Root
 const TooltipTrigger = RadixPrimitive.Trigger
 
 const tooltipContentVariants = cva(
-  'typography-label-6 z-50 overflow-hidden rounded-sm bg-reskin-bg-primary-inverse px-3 py-2 text-reskin-fg-primary-inverse shadow-lg ',
+  'typography-label-6 z-50 overflow-hidden rounded-sm bg-primary-inverse px-3 py-2 text-reskin-fg-primary-inverse shadow-lg ',
   {
     variants: {
       variant: {
@@ -64,12 +64,9 @@ const TooltipContent = React.forwardRef<
       {...props}
     >
       {children}
-      <RadixPrimitive.Arrow width={16} height={8} className="fill-reskin-base-black" asChild>
-        <svg width="16" height="8" viewBox="0 0 17 9" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path
-            d="M14.1442 0C15.0351 0 16.5 0 16.5 0L8.78023 7.77818C8.3897 8.16871 7.75654 8.16871 7.36601 7.77818L0.5 0H2.00206H14.1442Z"
-            className="fill-reskin-bg-primary-inverse"
-          />
+      <RadixPrimitive.Arrow width={16} height={8} className="text-primary" asChild>
+        <svg width="16" height="8" viewBox="0 0 17 9" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+          <path d="M14.1442 0C15.0351 0 16.5 0 16.5 0L8.78023 7.77818C8.3897 8.16871 7.75654 8.16871 7.36601 7.77818L0.5 0H2.00206H14.1442Z" />
         </svg>
       </RadixPrimitive.Arrow>
     </RadixPrimitive.Content>

--- a/packages/app/src/ui/molecules/new/alert/Alert.tsx
+++ b/packages/app/src/ui/molecules/new/alert/Alert.tsx
@@ -50,9 +50,9 @@ Alert.displayName = 'Alert'
 const alertVariants = cva('typography-label-6 grid grid-cols-[auto_1fr] items-center gap-3 rounded-sm p-4', {
   variants: {
     variant: {
-      info: 'bg-reskin-bg-brand-primary text-brand',
-      warning: 'bg-reskin-bg-system-warning-primary text-warning',
-      error: 'bg-reskin-bg-system-error-primary text-error',
+      info: 'bg-brand-primary text-brand',
+      warning: 'bg-system-warning-primary text-warning',
+      error: 'bg-system-error-primary text-error',
     },
     closable: {
       true: 'grid-cols-[auto_1fr_auto]',

--- a/packages/app/src/ui/molecules/new/asset-selector/AssetSelector.tsx
+++ b/packages/app/src/ui/molecules/new/asset-selector/AssetSelector.tsx
@@ -26,7 +26,7 @@ export function AssetSelector({
       <div
         className={cn(
           'flex w-full items-center justify-between p-3',
-          'rounded-sm border border-reskin-border-primary bg-reskin-bg-primary text-reskin-fg-primary',
+          'rounded-sm border border-primary bg-primary text-reskin-fg-primary',
           disabled && 'cursor-not-allowed opacity-50',
         )}
         data-testid={testIds.component.AssetSelector.trigger}

--- a/packages/app/src/ui/molecules/new/topbar-navigation/TopbarButton.tsx
+++ b/packages/app/src/ui/molecules/new/topbar-navigation/TopbarButton.tsx
@@ -5,18 +5,26 @@ import { NavLink, To, useMatch } from 'react-router-dom'
 
 const buttonVariants = cva(
   cn(
-    'typography-label-4 inline-flex h-10 flex-nowrap items-center gap-2 rounded-sm bg-reskin-bg-primary px-4 py-3',
-    'group border border-reskin-border-primary border-solid border-opacity-40 shadow-xs transition-colors focus-visible:outline-none focus-visible:ring focus-visible:ring-1 ',
+    'typography-label-4 inline-flex h-10 flex-nowrap items-center',
+    'group gap-2 rounded-sm border border-primary bg-primary px-4 py-3',
+    'border-solid border-opacity-40 shadow-xs transition-colors',
+    'focus-visible:outline-none focus-visible:ring focus-visible:ring-1 ',
   ),
   {
     variants: {
       type: {
-        savings:
-          'active:border-reskin-page-savings hover:border-reskin-page-savings/40 hover:shadow-reskin-page-savings/15 focus-visible:ring-reskin-page-savings',
-        farms:
-          'active:border-reskin-page-farm hover:border-reskin-page-farms/40 hover:shadow-reskin-page-farms/15 focus-visible:ring-reskin-page-farms',
-        borrow:
-          'active:border-reskin-page-borrow hover:border-reskin-page-borrow/40 hover:shadow-reskin-page-borrow/15 focus-visible:ring-reskin-page-borrow',
+        savings: cn(
+          'active:border-reskin-page-savings hover:border-reskin-page-savings/40',
+          'hover:shadow-reskin-page-savings/15 focus-visible:ring-reskin-page-savings',
+        ),
+        farms: cn(
+          'active:border-reskin-page-farm hover:border-reskin-page-farms/40',
+          'hover:shadow-reskin-page-farms/15 focus-visible:ring-reskin-page-farms',
+        ),
+        borrow: cn(
+          'active:border-reskin-page-borrow hover:border-reskin-page-borrow/40',
+          'hover:shadow-reskin-page-borrow/15 focus-visible:ring-reskin-page-borrow',
+        ),
       },
       isActive: {
         false: '',
@@ -66,7 +74,7 @@ export const TopbarButton = forwardRef<HTMLAnchorElement | HTMLButtonElement, To
         {label}
         {postfixSlot &&
           cloneElement(postfixSlot, {
-            className: 'icon-xs transition-colors group-hover:text-reskin-neutral-500',
+            className: 'icon-xs transition-colors group-hover:text-secondary',
           })}
       </>
     )

--- a/packages/app/src/ui/molecules/new/topbar-navigation/TopbarNavigation.tsx
+++ b/packages/app/src/ui/molecules/new/topbar-navigation/TopbarNavigation.tsx
@@ -95,7 +95,7 @@ export function TopbarNavigation({ savingsInfo, blockedPages, topbarNavigationIn
                   >
                     <div
                       className={cn(
-                        // @note - pointless to put this into config if its one time use - need to talk with designers about gradients
+                        // @note: one time use gradient
                         'absolute top-0 bottom-0 left-0 hidden w-[3px] bg-gradient-to-br from-[#FFCD4D] to-[#FF895D] opacity-0',
                         isActive && 'block opacity-1',
                       )}

--- a/packages/app/src/ui/organisms/new/asset-input/AssetInput.tsx
+++ b/packages/app/src/ui/organisms/new/asset-input/AssetInput.tsx
@@ -79,10 +79,10 @@ export function AssetInput<TFieldValues extends FieldValues>({
       <div
         className={cn(
           'grid grid-cols-[auto_1fr_auto] items-center gap-3 p-2 pr-4',
-          'rounded-sm border border-reskin-border-primary bg-reskin-bg-secondary',
-          'focus-within:border-reskin-border-brand-primary',
-          disabled && 'cursor-not-allowed bg-reskin-bg-secondary/50',
-          showError && error && 'border-reskin-bg-system-error-secondary bg-reskin-bg-system-error-primary',
+          'rounded-sm border border-primary bg-secondary',
+          'focus-within:border-brand-primary',
+          disabled && 'cursor-not-allowed bg-secondary/50',
+          showError && error && 'border-reskin-error-200 bg-system-error-primary',
         )}
       >
         <div className="min-w-[120px]">

--- a/packages/app/tailwind.config.ts
+++ b/packages/app/tailwind.config.ts
@@ -39,6 +39,71 @@ export default {
         warning: 'rgb(var(--warning-600))',
         error: 'rgb(var(--error-700))',
       },
+      borderColor: {
+        primary: 'rgb(var(--neutral-100))',
+        secondary: 'rgb(var(--neutral-200))',
+        tertiary: 'rgb(var(--neutral-300))',
+        quaternary: 'rgb(var(--neutral-400))',
+        brand: {
+          primary: 'rgb(var(--primary-400))',
+          secondary: 'rgb(var(--primary-500))',
+          tertiary: 'rgb(var(--primary-600))',
+        },
+        system: {
+          success: {
+            primary: 'rgb(var(--success-500))',
+            secondary: 'rgb(var(--success-600))',
+          },
+          warning: {
+            primary: 'rgb(var(--warning-500))',
+            secondary: 'rgb(var(--warning-600))',
+          },
+          error: {
+            primary: 'rgb(var(--error-500))',
+            secondary: 'rgb(var(--error-600))',
+          },
+          info: {
+            primary: 'rgb(var(--magenta-500))',
+            secondary: 'rgb(var(--magenta-600))',
+          },
+        },
+        focus: 'rgb(var(--primary-200))',
+      },
+      backgroundColor: {
+        primary: {
+          DEFAULT: 'rgb(var(--base-white))',
+          inverse: 'rgb(var(--base-black))',
+        },
+        secondary: {
+          DEFAULT: 'rgb(var(--neutral-50))',
+          inverse: 'rgb(var(--neutral-950))',
+        },
+        tertiary: 'rgb(var(--neutral-100))',
+        quaternary: 'rgb(var(--neutral-200))',
+        brand: {
+          primary: 'rgb(var(--primary-100))',
+          secondary: 'rgb(var(--primary-200))',
+          tertiary: 'rgb(var(--primary-300))',
+        },
+        system: {
+          success: {
+            primary: 'rgb(var(--success-100))',
+            secondary: 'rgb(var(--success-200))',
+          },
+          warning: {
+            primary: 'rgb(var(--warning-100))',
+            secondary: 'rgb(var(--warning-200))',
+          },
+          error: {
+            primary: 'rgb(var(--error-100))',
+            secondary: 'rgb(var(--error-200))',
+          },
+          info: {
+            primary: 'rgb(var(--magenta-100))',
+            secondary: 'rgb(var(--magenta-200))',
+          },
+        },
+      },
       colors: {
         reskin: {
           base: {
@@ -162,41 +227,6 @@ export default {
             borrow: 'rgb(var(--page-borrow))',
             farms: 'rgb(var(--page-farms))',
           },
-          bg: {
-            primary: {
-              DEFAULT: 'rgb(var(--base-white))',
-              inverse: 'rgb(var(--base-black))',
-            },
-            secondary: {
-              DEFAULT: 'rgb(var(--neutral-50))',
-              inverse: 'rgb(var(--neutral-950))',
-            },
-            tertiary: 'rgb(var(--neutral-100))',
-            quaternary: 'rgb(var(--neutral-200))',
-            brand: {
-              primary: 'rgb(var(--primary-100))',
-              secondary: 'rgb(var(--primary-200))',
-              tertiary: 'rgb(var(--primary-300))',
-            },
-            system: {
-              success: {
-                primary: 'rgb(var(--success-100))',
-                secondary: 'rgb(var(--success-200))',
-              },
-              warning: {
-                primary: 'rgb(var(--warning-100))',
-                secondary: 'rgb(var(--warning-200))',
-              },
-              error: {
-                primary: 'rgb(var(--error-100))',
-                secondary: 'rgb(var(--error-200))',
-              },
-              info: {
-                primary: 'rgb(var(--magenta-100))',
-                secondary: 'rgb(var(--magenta-200))',
-              },
-            },
-          },
           fg: {
             primary: {
               DEFAULT: 'rgb(var(--neutral-950))',
@@ -235,36 +265,6 @@ export default {
           },
           alpha: {
             dialog: 'color-mix(in srgb, rgb(var(--base-black)) 40%, transparent)',
-          },
-          border: {
-            primary: 'rgb(var(--neutral-100))',
-            secondary: 'rgb(var(--neutral-200))',
-            tertiary: 'rgb(var(--neutral-300))',
-            quaternary: 'rgb(var(--neutral-400))',
-            brand: {
-              primary: 'rgb(var(--primary-400))',
-              secondary: 'rgb(var(--primary-500))',
-              tertiary: 'rgb(var(--primary-600))',
-            },
-            system: {
-              success: {
-                primary: 'rgb(var(--success-500))',
-                secondary: 'rgb(var(--success-600))',
-              },
-              warning: {
-                primary: 'rgb(var(--warning-500))',
-                secondary: 'rgb(var(--warning-600))',
-              },
-              error: {
-                primary: 'rgb(var(--error-500))',
-                secondary: 'rgb(var(--error-600))',
-              },
-              info: {
-                primary: 'rgb(var(--magenta-500))',
-                secondary: 'rgb(var(--magenta-600))',
-              },
-            },
-            focus: 'rgb(var(--primary-200))',
           },
         },
         basics: {

--- a/packages/app/tailwind.config.ts
+++ b/packages/app/tailwind.config.ts
@@ -30,11 +30,13 @@ export default {
         roobert: ['Roobert', ...defaultTheme.fontFamily.sans],
       },
       textColor: {
-        primary: 'rgb(var(--base-black))',
+        primary: {
+          DEFAULT: 'rgb(var(--base-black))',
+          inverse: 'rgb(var(--base-white))',
+        },
         secondary: 'rgb(var(--neutral-500))',
         tertiary: 'rgb(var(--neutral-300))',
         brand: 'rgb(var(--primary-800))',
-        inverse: 'rgb(var(--base-white))',
         success: 'rgb(var(--success-600))',
         warning: 'rgb(var(--warning-600))',
         error: 'rgb(var(--error-700))',
@@ -348,7 +350,7 @@ export default {
         'gradient-purple': 'linear-gradient(90.22deg, #7A6BFF 0.12%, #BDDEFF 49.95%, #FFFFFF 99.78%)',
         'gradient-magenta': 'linear-gradient(89.84deg, #FA43BD -2.08%, #FFB5B5 48.92%, #FFFFFF 99.92%)',
         'gradient-green': 'linear-gradient(90deg, #11B93E 0%, #40DA69 50.47%, #FFFFFF 100%)',
-        'savings-gradient': 'radial-gradient(155.75% 155.75% at 50% 155.75%, #FFEF79 0%, #00C2A1 100%)',
+        'gradient-savings': 'radial-gradient(155.75% 155.75% at 50% 155.75%, #FFEF79 0%, #00C2A1 100%)',
       },
       fontWeight: {
         regular: '400',


### PR DESCRIPTION
Moved `bg` and `border` from `colors` to it's own properties (`borderColor` and `backgroundColor`) in tailwind config. It simplified classes usage, e.g.:
`bg-reskin-bg-primary-inverse` -> `bg-primary-inverse`
`border-reskin-border-primary` -> `border-primary`.

In addition, not having `bg/border` directly in colors config prevents from using those in unrelated context - for example you can't do `ring-reskin-border-primary`, which makes sense, since ring is a shadow and normally shouldn't have access to border color properties (default behavior in tailwind).
