### PR TITLE
Remove postfix and prefix icons from button props

### DIFF
--- a/packages/app/src/ui/atoms/new/button/Button.stories.tsx
+++ b/packages/app/src/ui/atoms/new/button/Button.stories.tsx
@@ -1,14 +1,61 @@
 import { StoryGrid } from '@sb/components/StoryGrid'
 import type { Meta, StoryObj } from '@storybook/react'
 import { ChevronRightIcon, PlusIcon } from 'lucide-react'
-import { Button, ButtonIcon } from './Button'
+import { Button, ButtonIcon, ButtonProps } from './Button'
 
 const meta: Meta<typeof Button> = {
   title: 'Components/Atoms/New/Button',
-  args: {
-    children: 'Button',
-  },
   component: (args) => (
+    <div className="flex flex-col gap-4">
+      <ButtonStoryGrid {...args} />
+      <IconButtonStoryGrid {...args} />
+    </div>
+  ),
+}
+
+export default meta
+type Story = StoryObj<typeof Button>
+
+export const Default: Story = {}
+
+export const Hovered: Story = {
+  parameters: {
+    pseudo: {
+      hover: true,
+    },
+  },
+}
+
+export const Focused: Story = {
+  parameters: {
+    pseudo: {
+      focusVisible: true,
+    },
+  },
+}
+
+export const Pressed: Story = {
+  parameters: {
+    pseudo: {
+      active: true,
+    },
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+}
+
+export const Loading: Story = {
+  args: {
+    loading: true,
+  },
+}
+
+function ButtonStoryGrid(args: ButtonProps) {
+  return (
     <StoryGrid className="grid-cols-3">
       <StoryGrid.Label>Primary</StoryGrid.Label>
       <StoryGrid.Label>Secondary</StoryGrid.Label>
@@ -62,46 +109,45 @@ const meta: Meta<typeof Button> = {
         <ButtonIcon icon={ChevronRightIcon} />
       </Button>
     </StoryGrid>
-  ),
+  )
 }
 
-export default meta
-type Story = StoryObj<typeof Button>
+function IconButtonStoryGrid(args: ButtonProps) {
+  return (
+    <StoryGrid className="grid-cols-3">
+      <StoryGrid.Label>Primary</StoryGrid.Label>
+      <StoryGrid.Label>Secondary</StoryGrid.Label>
+      <StoryGrid.Label>Tertiary</StoryGrid.Label>
 
-export const Default: Story = {}
+      <Button {...args} variant="primary" size="l">
+        <ButtonIcon icon={PlusIcon} />
+      </Button>
+      <Button {...args} variant="secondary" size="l">
+        <ButtonIcon icon={PlusIcon} />
+      </Button>
+      <Button {...args} variant="tertiary" size="l">
+        <ButtonIcon icon={PlusIcon} />
+      </Button>
 
-export const Hovered: Story = {
-  parameters: {
-    pseudo: {
-      hover: true,
-    },
-  },
-}
+      <Button {...args} variant="primary" size="m">
+        <ButtonIcon icon={PlusIcon} />
+      </Button>
+      <Button {...args} variant="secondary" size="m">
+        <ButtonIcon icon={PlusIcon} />
+      </Button>
+      <Button {...args} variant="tertiary" size="m">
+        <ButtonIcon icon={PlusIcon} />
+      </Button>
 
-export const Focused: Story = {
-  parameters: {
-    pseudo: {
-      focusVisible: true,
-    },
-  },
-}
-
-export const Pressed: Story = {
-  parameters: {
-    pseudo: {
-      active: true,
-    },
-  },
-}
-
-export const Disabled: Story = {
-  args: {
-    disabled: true,
-  },
-}
-
-export const Loading: Story = {
-  args: {
-    loading: true,
-  },
+      <Button {...args} variant="primary" size="s">
+        <ButtonIcon icon={PlusIcon} />
+      </Button>
+      <Button {...args} variant="secondary" size="s">
+        <ButtonIcon icon={PlusIcon} />
+      </Button>
+      <Button {...args} variant="tertiary" size="s">
+        <ButtonIcon icon={PlusIcon} />
+      </Button>
+    </StoryGrid>
+  )
 }

--- a/packages/app/src/ui/atoms/new/button/Button.stories.tsx
+++ b/packages/app/src/ui/atoms/new/button/Button.stories.tsx
@@ -1,15 +1,64 @@
 import { StoryGrid } from '@sb/components/StoryGrid'
 import type { Meta, StoryObj } from '@storybook/react'
 import { ChevronRightIcon, PlusIcon } from 'lucide-react'
-import { Button, ButtonIcon, ButtonProps } from './Button'
+import { Button, ButtonIcon } from './Button'
 
 const meta: Meta<typeof Button> = {
   title: 'Components/Atoms/New/Button',
   component: (args) => (
-    <div className="flex flex-col gap-4">
-      <ButtonStoryGrid {...args} />
-      <IconButtonStoryGrid {...args} />
-    </div>
+    <StoryGrid className="grid-cols-3">
+      <StoryGrid.Label>Primary</StoryGrid.Label>
+      <StoryGrid.Label>Secondary</StoryGrid.Label>
+      <StoryGrid.Label>Tertiary</StoryGrid.Label>
+
+      <Button {...args} variant="primary" size="l">
+        <ButtonIcon icon={PlusIcon} />
+        Button
+        <ButtonIcon icon={ChevronRightIcon} />
+      </Button>
+      <Button {...args} variant="secondary" size="l">
+        <ButtonIcon icon={PlusIcon} />
+        Button
+        <ButtonIcon icon={ChevronRightIcon} />
+      </Button>
+      <Button {...args} variant="tertiary" size="l">
+        <ButtonIcon icon={PlusIcon} />
+        Button
+        <ButtonIcon icon={ChevronRightIcon} />
+      </Button>
+
+      <Button {...args} variant="primary" size="m">
+        <ButtonIcon icon={PlusIcon} />
+        Button
+        <ButtonIcon icon={ChevronRightIcon} />
+      </Button>
+      <Button {...args} variant="secondary" size="m">
+        <ButtonIcon icon={PlusIcon} />
+        Button
+        <ButtonIcon icon={ChevronRightIcon} />
+      </Button>
+      <Button {...args} variant="tertiary" size="m">
+        <ButtonIcon icon={PlusIcon} />
+        Button
+        <ButtonIcon icon={ChevronRightIcon} />
+      </Button>
+
+      <Button {...args} variant="primary" size="s">
+        <ButtonIcon icon={PlusIcon} />
+        Button
+        <ButtonIcon icon={ChevronRightIcon} />
+      </Button>
+      <Button {...args} variant="secondary" size="s">
+        <ButtonIcon icon={PlusIcon} />
+        Button
+        <ButtonIcon icon={ChevronRightIcon} />
+      </Button>
+      <Button {...args} variant="tertiary" size="s">
+        <ButtonIcon icon={PlusIcon} />
+        Button
+        <ButtonIcon icon={ChevronRightIcon} />
+      </Button>
+    </StoryGrid>
   ),
 }
 
@@ -52,102 +101,4 @@ export const Loading: Story = {
   args: {
     loading: true,
   },
-}
-
-function ButtonStoryGrid(args: ButtonProps) {
-  return (
-    <StoryGrid className="grid-cols-3">
-      <StoryGrid.Label>Primary</StoryGrid.Label>
-      <StoryGrid.Label>Secondary</StoryGrid.Label>
-      <StoryGrid.Label>Tertiary</StoryGrid.Label>
-
-      <Button {...args} variant="primary" size="l">
-        <ButtonIcon icon={PlusIcon} />
-        Button
-        <ButtonIcon icon={ChevronRightIcon} />
-      </Button>
-      <Button {...args} variant="secondary" size="l">
-        <ButtonIcon icon={PlusIcon} />
-        Button
-        <ButtonIcon icon={ChevronRightIcon} />
-      </Button>
-      <Button {...args} variant="tertiary" size="l">
-        <ButtonIcon icon={PlusIcon} />
-        Button
-        <ButtonIcon icon={ChevronRightIcon} />
-      </Button>
-
-      <Button {...args} variant="primary" size="m">
-        <ButtonIcon icon={PlusIcon} />
-        Button
-        <ButtonIcon icon={ChevronRightIcon} />
-      </Button>
-      <Button {...args} variant="secondary" size="m">
-        <ButtonIcon icon={PlusIcon} />
-        Button
-        <ButtonIcon icon={ChevronRightIcon} />
-      </Button>
-      <Button {...args} variant="tertiary" size="m">
-        <ButtonIcon icon={PlusIcon} />
-        Button
-        <ButtonIcon icon={ChevronRightIcon} />
-      </Button>
-
-      <Button {...args} variant="primary" size="s">
-        <ButtonIcon icon={PlusIcon} />
-        Button
-        <ButtonIcon icon={ChevronRightIcon} />
-      </Button>
-      <Button {...args} variant="secondary" size="s">
-        <ButtonIcon icon={PlusIcon} />
-        Button
-        <ButtonIcon icon={ChevronRightIcon} />
-      </Button>
-      <Button {...args} variant="tertiary" size="s">
-        <ButtonIcon icon={PlusIcon} />
-        Button
-        <ButtonIcon icon={ChevronRightIcon} />
-      </Button>
-    </StoryGrid>
-  )
-}
-
-function IconButtonStoryGrid(args: ButtonProps) {
-  return (
-    <StoryGrid className="grid-cols-3">
-      <StoryGrid.Label>Primary</StoryGrid.Label>
-      <StoryGrid.Label>Secondary</StoryGrid.Label>
-      <StoryGrid.Label>Tertiary</StoryGrid.Label>
-
-      <Button {...args} variant="primary" size="l">
-        <ButtonIcon icon={PlusIcon} />
-      </Button>
-      <Button {...args} variant="secondary" size="l">
-        <ButtonIcon icon={PlusIcon} />
-      </Button>
-      <Button {...args} variant="tertiary" size="l">
-        <ButtonIcon icon={PlusIcon} />
-      </Button>
-
-      <Button {...args} variant="primary" size="m">
-        <ButtonIcon icon={PlusIcon} />
-      </Button>
-      <Button {...args} variant="secondary" size="m">
-        <ButtonIcon icon={PlusIcon} />
-      </Button>
-      <Button {...args} variant="tertiary" size="m">
-        <ButtonIcon icon={PlusIcon} />
-      </Button>
-
-      <Button {...args} variant="primary" size="s">
-        <ButtonIcon icon={PlusIcon} />
-      </Button>
-      <Button {...args} variant="secondary" size="s">
-        <ButtonIcon icon={PlusIcon} />
-      </Button>
-      <Button {...args} variant="tertiary" size="s">
-        <ButtonIcon icon={PlusIcon} />
-      </Button>
-    </StoryGrid>
-  )
 }

--- a/packages/app/src/ui/atoms/new/button/Button.stories.tsx
+++ b/packages/app/src/ui/atoms/new/button/Button.stories.tsx
@@ -1,32 +1,66 @@
 import { StoryGrid } from '@sb/components/StoryGrid'
 import type { Meta, StoryObj } from '@storybook/react'
 import { ChevronRightIcon, PlusIcon } from 'lucide-react'
-import { Button, ButtonProps } from './Button'
+import { Button, ButtonIcon } from './Button'
 
 const meta: Meta<typeof Button> = {
   title: 'Components/Atoms/New/Button',
   args: {
     children: 'Button',
-    prefixIcon: PlusIcon,
-    postfixIcon: ChevronRightIcon,
   },
-  component: (props: ButtonProps) => (
+  component: (args) => (
     <StoryGrid className="grid-cols-3">
       <StoryGrid.Label>Primary</StoryGrid.Label>
       <StoryGrid.Label>Secondary</StoryGrid.Label>
       <StoryGrid.Label>Tertiary</StoryGrid.Label>
 
-      <Button variant="primary" size="l" {...props} />
-      <Button variant="secondary" size="l" {...props} />
-      <Button variant="tertiary" size="l" {...props} />
+      <Button {...args} variant="primary" size="l">
+        <ButtonIcon icon={PlusIcon} />
+        Button
+        <ButtonIcon icon={ChevronRightIcon} />
+      </Button>
+      <Button {...args} variant="secondary" size="l">
+        <ButtonIcon icon={PlusIcon} />
+        Button
+        <ButtonIcon icon={ChevronRightIcon} />
+      </Button>
+      <Button {...args} variant="tertiary" size="l">
+        <ButtonIcon icon={PlusIcon} />
+        Button
+        <ButtonIcon icon={ChevronRightIcon} />
+      </Button>
 
-      <Button variant="primary" size="m" {...props} />
-      <Button variant="secondary" size="m" {...props} />
-      <Button variant="tertiary" size="m" {...props} />
+      <Button {...args} variant="primary" size="m">
+        <ButtonIcon icon={PlusIcon} />
+        Button
+        <ButtonIcon icon={ChevronRightIcon} />
+      </Button>
+      <Button {...args} variant="secondary" size="m">
+        <ButtonIcon icon={PlusIcon} />
+        Button
+        <ButtonIcon icon={ChevronRightIcon} />
+      </Button>
+      <Button {...args} variant="tertiary" size="m">
+        <ButtonIcon icon={PlusIcon} />
+        Button
+        <ButtonIcon icon={ChevronRightIcon} />
+      </Button>
 
-      <Button variant="primary" size="s" {...props} />
-      <Button variant="secondary" size="s" {...props} />
-      <Button variant="tertiary" size="s" {...props} />
+      <Button {...args} variant="primary" size="s">
+        <ButtonIcon icon={PlusIcon} />
+        Button
+        <ButtonIcon icon={ChevronRightIcon} />
+      </Button>
+      <Button {...args} variant="secondary" size="s">
+        <ButtonIcon icon={PlusIcon} />
+        Button
+        <ButtonIcon icon={ChevronRightIcon} />
+      </Button>
+      <Button {...args} variant="tertiary" size="s">
+        <ButtonIcon icon={PlusIcon} />
+        Button
+        <ButtonIcon icon={ChevronRightIcon} />
+      </Button>
     </StoryGrid>
   ),
 }

--- a/packages/app/src/ui/atoms/new/button/Button.tsx
+++ b/packages/app/src/ui/atoms/new/button/Button.tsx
@@ -49,8 +49,8 @@ const buttonVariants = cva(
 const buttonIconVariants = cva('', {
   variants: {
     size: {
-      l: 'icon-sm only:mx-0.5',
-      m: 'icon-sm only:mx-0.5',
+      l: 'icon-sm',
+      m: 'icon-sm',
       s: 'icon-xs',
     },
   },
@@ -68,7 +68,7 @@ function useButtonContext(): ButtonContextProps {
   return context
 }
 
-type IconType = React.ComponentType<{ className?: string }>
+export type ButtonIconType = React.ComponentType<{ className?: string }>
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
@@ -117,7 +117,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 Button.displayName = 'Button'
 
 interface ButtonIconProps {
-  icon: IconType
+  icon: ButtonIconType
 }
 
 export function ButtonIcon({ icon: Icon }: ButtonIconProps) {

--- a/packages/app/src/ui/atoms/new/button/Button.tsx
+++ b/packages/app/src/ui/atoms/new/button/Button.tsx
@@ -49,8 +49,8 @@ const buttonVariants = cva(
 const buttonIconVariants = cva('', {
   variants: {
     size: {
-      l: 'icon-sm',
-      m: 'icon-sm',
+      l: 'icon-sm only:mx-0.5',
+      m: 'icon-sm only:mx-0.5',
       s: 'icon-xs',
     },
   },

--- a/packages/app/src/ui/atoms/new/button/Button.tsx
+++ b/packages/app/src/ui/atoms/new/button/Button.tsx
@@ -3,11 +3,13 @@ import { type VariantProps, cva } from 'class-variance-authority'
 import * as React from 'react'
 
 import { cn } from '@/ui/utils/style'
+import { assert } from '@/utils/assert'
+import { RequiredProps } from '@/utils/types'
 import { Loader } from '../loader/Loader'
 
 const buttonVariants = cva(
   cn(
-    'relative isolate inline-flex select-none items-center justify-center gap-1 ',
+    'relative isolate inline-flex select-none items-center justify-center gap-2 ',
     'overflow-hidden whitespace-nowrap rounded-sm transition-colors ',
     'focus-visible:bg-reskin-base-white focus-visible:text-reskin-neutral-950 ',
     'focus-visible:outline-none focus-visible:ring focus-visible:ring-reskin-primary-200 focus-visible:ring-offset-0',
@@ -54,14 +56,24 @@ const buttonIconVariants = cva('', {
   },
 })
 
+type ButtonIconSize = NonNullable<VariantProps<typeof buttonIconVariants>['size']>
+interface ButtonContextProps {
+  size: ButtonIconSize
+}
+const ButtonContext = React.createContext<ButtonContextProps | null>(null)
+
+function useButtonContext(): ButtonContextProps {
+  const context = React.useContext(ButtonContext)
+  assert(context, 'useButtonContext must be used within a Button component')
+  return context
+}
+
 type IconType = React.ComponentType<{ className?: string }>
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
+    RequiredProps<VariantProps<typeof buttonVariants>> {
   asChild?: boolean
-  prefixIcon?: IconType
-  postfixIcon?: IconType
   loading?: boolean
 }
 
@@ -73,8 +85,6 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       size = 'm',
       asChild = false,
       type = 'button',
-      prefixIcon: PrefixIcon,
-      postfixIcon: PostfixIcon,
       loading = false,
       children,
       disabled,
@@ -99,14 +109,18 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
             <Loader size={20} />
           </div>
         )}
-        <>
-          {PrefixIcon && <PrefixIcon className={buttonIconVariants({ size })} />}
-          <div className="px-1">{children}</div>
-          {PostfixIcon && <PostfixIcon className={buttonIconVariants({ size })} />}
-        </>
+        <ButtonContext.Provider value={{ size }}>{children}</ButtonContext.Provider>
       </Comp>
     )
   },
 )
-
 Button.displayName = 'Button'
+
+interface ButtonIconProps {
+  icon: IconType
+}
+
+export function ButtonIcon({ icon: Icon }: ButtonIconProps) {
+  const { size } = useButtonContext()
+  return <Icon className={buttonIconVariants({ size })} />
+}

--- a/packages/app/src/ui/atoms/new/icon-button/IconButton.stories.tsx
+++ b/packages/app/src/ui/atoms/new/icon-button/IconButton.stories.tsx
@@ -1,0 +1,71 @@
+import { StoryGrid } from '@sb/components/StoryGrid'
+import type { Meta, StoryObj } from '@storybook/react'
+import { PlusIcon } from 'lucide-react'
+import { IconButton } from './IconButton'
+
+const meta: Meta<typeof IconButton> = {
+  title: 'Components/Atoms/New/IconButton',
+  args: {
+    icon: PlusIcon,
+  },
+  component: (args) => (
+    <StoryGrid className="grid-cols-3">
+      <StoryGrid.Label>Primary</StoryGrid.Label>
+      <StoryGrid.Label>Secondary</StoryGrid.Label>
+      <StoryGrid.Label>Tertiary</StoryGrid.Label>
+
+      <IconButton {...args} variant="primary" size="l" />
+      <IconButton {...args} variant="secondary" size="l" />
+      <IconButton {...args} variant="tertiary" size="l" />
+
+      <IconButton {...args} variant="primary" size="m" />
+      <IconButton {...args} variant="secondary" size="m" />
+      <IconButton {...args} variant="tertiary" size="m" />
+
+      <IconButton {...args} variant="primary" size="s" />
+      <IconButton {...args} variant="secondary" size="s" />
+      <IconButton {...args} variant="tertiary" size="s" />
+    </StoryGrid>
+  ),
+}
+
+export default meta
+type Story = StoryObj<typeof IconButton>
+
+export const Default: Story = {}
+
+export const Hovered: Story = {
+  parameters: {
+    pseudo: {
+      hover: true,
+    },
+  },
+}
+
+export const Focused: Story = {
+  parameters: {
+    pseudo: {
+      focusVisible: true,
+    },
+  },
+}
+
+export const Pressed: Story = {
+  parameters: {
+    pseudo: {
+      active: true,
+    },
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+}
+
+export const Loading: Story = {
+  args: {
+    loading: true,
+  },
+}

--- a/packages/app/src/ui/atoms/new/icon-button/IconButton.tsx
+++ b/packages/app/src/ui/atoms/new/icon-button/IconButton.tsx
@@ -1,0 +1,34 @@
+import { cva } from 'class-variance-authority'
+import * as React from 'react'
+
+import { cn } from '@/ui/utils/style'
+import { Button, ButtonIcon, ButtonIconType, ButtonProps } from '../button/Button'
+
+const iconButtonSizeVariants = cva('aspect-square', {
+  variants: {
+    size: {
+      l: 'p-3.5',
+      m: 'p-2.5',
+      s: 'p-2',
+    },
+  },
+  defaultVariants: {
+    size: 'm',
+  },
+})
+
+export interface IconButtonProps extends Omit<ButtonProps, 'children'> {
+  icon: ButtonIconType
+}
+
+export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
+  ({ className, size = 'm', icon, ...props }, ref) => {
+    return (
+      <Button {...props} className={cn(iconButtonSizeVariants({ size }), className)} ref={ref} size={size}>
+        <ButtonIcon icon={icon} />
+      </Button>
+    )
+  },
+)
+
+IconButton.displayName = 'Button'


### PR DESCRIPTION
Quick poc to show how we can have flexibility of providing custom icons to Button, but at the same time having Icon scaled correctly depending on button size, without explicitly passing same size prop for button and icon each time.

Using button with icon could look like:
```<Button size="m"><ButtonIcon icon={PlusIcon} />Button Text</Button>```

You pass variant only for `Button`, and `ButtonIcon` is automatically getting it thanks that it's wrapped by `Button` component.

I saw similar pattern before in radix and shadcn.
https://github.com/shadcn-ui/ui/blob/500a353816969e3cce2b3f4f0699ce4e6ad06f0b/apps/www/registry/default/ui/carousel.tsx#L24