### PR TITLE
Add readme note about enforcing pnpm version at Vercel's build

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Exact pnpm version `9.14.2` is required. Install with:
 curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=9.14.2 sh -
 ```
 
+To enforce Vercel build to use exact pnpm version, add environment variable at Vercel project settings. This way Vercel will use exact pnpm version specified in root package.json.
+```sh
+ENABLE_EXPERIMENTAL_COREPACK=1
+```
+
+
 ## Directory structure
 
 - `ui` folder should only contain reusable chunks of code responsible only for rendering, any data should be passed via


### PR DESCRIPTION
Vercel, during build, will automatically use latest pnpm version.

To make Vercel use specific pnpm version:
- environment variable at Vercel's project must be added: `ENABLE_EXPERIMENTAL_COREPACK=1`
- specific pnpm version must be set at root package.json: `"packageManager": "pnpm@9.14.2"`