### PR TITLE
Fix promise logging

### DIFF
--- a/packages/common-nodejs/src/logger/Logger.test.ts
+++ b/packages/common-nodejs/src/logger/Logger.test.ts
@@ -80,6 +80,25 @@ describe(Logger.name, () => {
     expect(transport.log).toHaveBeenOnlyCalledWith(lines.join(''))
   })
 
+  it('marks promised values in pretty output', () => {
+    const transport = createTestTransport()
+    const logger = new Logger({
+      transports: [
+        {
+          transport: transport,
+          formatter: new LogFormatterPretty({ colors: false, utc: true }),
+        },
+      ],
+      logLevel: 'TRACE',
+      getTime: () => new Date(0),
+      utc: true,
+    })
+
+    logger.info({ test: Promise.resolve(1234) })
+    const lines = ['00:00:00.000Z INFO\n', "    { test: 'Promise' }", '']
+    expect(transport.log).toHaveBeenOnlyCalledWith(lines.join(''))
+  })
+
   describe('for', () => {
     function setup() {
       const transport = createTestTransport()

--- a/packages/common-nodejs/src/logger/utils.ts
+++ b/packages/common-nodejs/src/logger/utils.ts
@@ -1,6 +1,22 @@
 /* eslint-disable */
 export function toJSON(parameters: object): string {
-  return JSON.stringify(parameters, (_k, v: unknown) => (typeof v === 'bigint' ? v.toString() : v))
+  return JSON.stringify(parameters, (_k, v: unknown) => {
+    if (typeof v === 'bigint') {
+      return v.toString()
+    }
+
+    // uses a generic check to catch any promise-like objects (e.g. Promise, Bluebird, etc.)
+    const isPromise =
+      typeof v === 'object' &&
+      v !== null &&
+      typeof (v as any).then === 'function' &&
+      typeof (v as any).catch === 'function'
+    if (isPromise) {
+      return 'Promise'
+    }
+
+    return v
+  })
 }
 
 export function formatDate(date: Date): string {


### PR DESCRIPTION
Before, promises were logged as `{}`. Now it should be easier to spot such mistakes and fix the logging. 

The best would be to simply prevent from passing `Promise` instances to logger but I don't think it's doable right now...