### PR TITLE
Be less strict when filtering errors with third party stack frames

### DIFF
--- a/packages/app/src/utils/sentry/index.ts
+++ b/packages/app/src/utils/sentry/index.ts
@@ -23,7 +23,7 @@ Sentry.init({
     // allows to filter out third party errors (browser extensions, code-injection, etc.)
     Sentry.thirdPartyErrorFilterIntegration({
       filterKeys: [import.meta.env.VITE_SENTRY_APPLICATION_KEY],
-      behaviour: 'drop-error-if-contains-third-party-frames',
+      behaviour: 'drop-error-if-exclusively-contains-third-party-frames',
     }),
   ],
   tracesSampleRate: 0,


### PR DESCRIPTION
Just a small adjustment to sentry filtering integration. It can be made more strict if we see to much of third party errors at sentry.