### PR TITLE
Common packages improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "check:fix": "biome check --write --unsafe .",
     "build": "pnpm run --aggregate-output --reporter append-only --filter './packages/**' build",
     "verify": "pnpm run --parallel --aggregate-output --reporter append-only --filter './packages/**' verify",
+    "typecheck": "pnpm run --parallel --aggregate-output --reporter append-only --filter './packages/**' typecheck",
     "fix": "pnpm run check:fix && pnpm run verify",
     "clean": "pnpm run --parallel --aggregate-output --reporter append-only --filter './packages/**' clean"
   },

--- a/packages/app/src/features/dialogs/borrow/BorrowDialog.test-e2e.ts
+++ b/packages/app/src/features/dialogs/borrow/BorrowDialog.test-e2e.ts
@@ -32,7 +32,7 @@ test.describe('Borrow dialog', () => {
       const testContext = await setup(page, {
         blockchain: {
           blockNumber: DEFAULT_BLOCK_NUMBER,
-          chainId: mainnet.id,
+          chain: mainnet,
         },
         initialPage: 'easyBorrow',
         account: {
@@ -182,7 +182,7 @@ test.describe('Borrow dialog', () => {
       const testContext = await setup(page, {
         blockchain: {
           blockNumber: DEFAULT_BLOCK_NUMBER,
-          chainId: mainnet.id,
+          chain: mainnet,
         },
         initialPage: 'easyBorrow',
         account: {
@@ -276,7 +276,7 @@ test.describe('Borrow dialog', () => {
       const testContext = await setup(page, {
         blockchain: {
           blockNumber: 20230000n,
-          chainId: mainnet.id,
+          chain: mainnet,
         },
         initialPage: 'myPortfolio',
         account: {
@@ -327,7 +327,7 @@ test.describe('Borrow dialog', () => {
       const testContext = await setup(page, {
         blockchain: {
           blockNumber: DEFAULT_BLOCK_NUMBER,
-          chainId: mainnet.id,
+          chain: mainnet,
         },
         initialPage: 'myPortfolio',
         account: {
@@ -378,7 +378,7 @@ test.describe('Borrow dialog', () => {
       const testContext = await setup(page, {
         blockchain: {
           blockNumber: DEFAULT_BLOCK_NUMBER,
-          chainId: mainnet.id,
+          chain: mainnet,
         },
         initialPage: 'easyBorrow',
         account: {

--- a/packages/app/src/features/dialogs/claim-rewards/ClaimRewardsDialog.test-e2e.ts
+++ b/packages/app/src/features/dialogs/claim-rewards/ClaimRewardsDialog.test-e2e.ts
@@ -15,7 +15,7 @@ test.describe('Claim rewards dialog', () => {
     testContext = await setup(page, {
       blockchain: {
         blockNumber: DEFAULT_BLOCK_NUMBER,
-        chainId: mainnet.id,
+        chain: mainnet,
       },
       initialPage: 'easyBorrow',
       account: {

--- a/packages/app/src/features/dialogs/collateral/CollateralDialog.test-e2e.ts
+++ b/packages/app/src/features/dialogs/collateral/CollateralDialog.test-e2e.ts
@@ -31,7 +31,7 @@ test.describe('Collateral dialog', () => {
       const testContext = await setup(page, {
         blockchain: {
           blockNumber: DEFAULT_BLOCK_NUMBER,
-          chainId: mainnet.id,
+          chain: mainnet,
         },
         initialPage: 'easyBorrow',
         account: {
@@ -138,7 +138,7 @@ test.describe('Collateral dialog', () => {
       const testContext = await setup(page, {
         blockchain: {
           blockNumber: DEFAULT_BLOCK_NUMBER,
-          chainId: mainnet.id,
+          chain: mainnet,
         },
         initialPage: 'easyBorrow',
         account: {
@@ -190,7 +190,7 @@ test.describe('Collateral dialog', () => {
       const testContext = await setup(page, {
         blockchain: {
           blockNumber: DEFAULT_BLOCK_NUMBER,
-          chainId: mainnet.id,
+          chain: mainnet,
         },
         initialPage: 'easyBorrow',
         account: {
@@ -263,7 +263,7 @@ test.describe('Collateral dialog', () => {
       const testContext = await setup(page, {
         blockchain: {
           blockNumber: DEFAULT_BLOCK_NUMBER,
-          chainId: mainnet.id,
+          chain: mainnet,
         },
         initialPage: 'easyBorrow',
         account: {
@@ -328,7 +328,7 @@ test.describe('Collateral dialog', () => {
         const testContext = await setup(page, {
           blockchain: {
             blockNumber: DEFAULT_BLOCK_NUMBER,
-            chainId: mainnet.id,
+            chain: mainnet,
           },
           initialPage: 'easyBorrow',
           account: {
@@ -386,7 +386,7 @@ test.describe('Collateral dialog', () => {
         const testContext = await setup(page, {
           blockchain: {
             blockNumber: DEFAULT_BLOCK_NUMBER,
-            chainId: mainnet.id,
+            chain: mainnet,
           },
           initialPage: 'easyBorrow',
           account: {

--- a/packages/app/src/features/dialogs/convert-stables/ConvertStablesDialog.test-e2e.ts
+++ b/packages/app/src/features/dialogs/convert-stables/ConvertStablesDialog.test-e2e.ts
@@ -13,7 +13,7 @@ test.describe('Convert Stables Dialog', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: DEFAULT_BLOCK_NUMBER,
-        chainId: mainnet.id,
+        chain: mainnet,
       },
       initialPage: 'savings',
       account: {

--- a/packages/app/src/features/dialogs/convert-stables/e2e/base/UsdcToUsds.test-e2e.ts
+++ b/packages/app/src/features/dialogs/convert-stables/e2e/base/UsdcToUsds.test-e2e.ts
@@ -13,7 +13,7 @@ test.describe('Convert USDC to USDS', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: BASE_DEFAULT_BLOCK_NUMBER,
-        chainId: base.id,
+        chain: base,
       },
       initialPage: 'savings',
       account: {

--- a/packages/app/src/features/dialogs/convert-stables/e2e/base/UsdsToUsdc.test-e2e.ts
+++ b/packages/app/src/features/dialogs/convert-stables/e2e/base/UsdsToUsdc.test-e2e.ts
@@ -13,7 +13,7 @@ test.describe('Convert USDS to USDC', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: BASE_DEFAULT_BLOCK_NUMBER,
-        chainId: base.id,
+        chain: base,
       },
       initialPage: 'savings',
       account: {

--- a/packages/app/src/features/dialogs/convert-stables/e2e/mainnet/DaiToUsdc.test-e2e.ts
+++ b/packages/app/src/features/dialogs/convert-stables/e2e/mainnet/DaiToUsdc.test-e2e.ts
@@ -13,7 +13,7 @@ test.describe('Convert DAI to USDC', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: DEFAULT_BLOCK_NUMBER,
-        chainId: mainnet.id,
+        chain: mainnet,
       },
       initialPage: 'savings',
       account: {

--- a/packages/app/src/features/dialogs/convert-stables/e2e/mainnet/DaiToUsds.test-e2e.ts
+++ b/packages/app/src/features/dialogs/convert-stables/e2e/mainnet/DaiToUsds.test-e2e.ts
@@ -13,7 +13,7 @@ test.describe('Convert DAI to USDS', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: DEFAULT_BLOCK_NUMBER,
-        chainId: mainnet.id,
+        chain: mainnet,
       },
       initialPage: 'savings',
       account: {

--- a/packages/app/src/features/dialogs/convert-stables/e2e/mainnet/UsdcToDai.test-e2e.ts
+++ b/packages/app/src/features/dialogs/convert-stables/e2e/mainnet/UsdcToDai.test-e2e.ts
@@ -13,7 +13,7 @@ test.describe('Convert USDC to DAI', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: DEFAULT_BLOCK_NUMBER,
-        chainId: mainnet.id,
+        chain: mainnet,
       },
       initialPage: 'savings',
       account: {

--- a/packages/app/src/features/dialogs/convert-stables/e2e/mainnet/UsdcToUsds.test-e2e.ts
+++ b/packages/app/src/features/dialogs/convert-stables/e2e/mainnet/UsdcToUsds.test-e2e.ts
@@ -13,7 +13,7 @@ test.describe('Convert USDC to USDS', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: DEFAULT_BLOCK_NUMBER,
-        chainId: mainnet.id,
+        chain: mainnet,
       },
       initialPage: 'savings',
       account: {

--- a/packages/app/src/features/dialogs/convert-stables/e2e/mainnet/UsdsToDai.test-e2e.ts
+++ b/packages/app/src/features/dialogs/convert-stables/e2e/mainnet/UsdsToDai.test-e2e.ts
@@ -13,7 +13,7 @@ test.describe('Convert USDS to DAI', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: DEFAULT_BLOCK_NUMBER,
-        chainId: mainnet.id,
+        chain: mainnet,
       },
       initialPage: 'savings',
       account: {

--- a/packages/app/src/features/dialogs/convert-stables/e2e/mainnet/UsdsToUsdc.test-e2e.ts
+++ b/packages/app/src/features/dialogs/convert-stables/e2e/mainnet/UsdsToUsdc.test-e2e.ts
@@ -13,7 +13,7 @@ test.describe('Convert USDS to USDC', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: DEFAULT_BLOCK_NUMBER,
-        chainId: mainnet.id,
+        chain: mainnet,
       },
       initialPage: 'savings',
       account: {

--- a/packages/app/src/features/dialogs/deposit/DepositDialog.test-e2e.ts
+++ b/packages/app/src/features/dialogs/deposit/DepositDialog.test-e2e.ts
@@ -33,7 +33,7 @@ test.describe('Deposit dialog', () => {
     test.beforeEach(async ({ page }) => {
       const testContext = await setup(page, {
         blockchain: {
-          chainId: mainnet.id,
+          chain: mainnet,
           blockNumber: DEFAULT_BLOCK_NUMBER,
         },
         initialPage: 'easyBorrow',
@@ -256,7 +256,7 @@ test.describe('Deposit dialog', () => {
     test.beforeEach(async ({ page }) => {
       const testContext = await setup(page, {
         blockchain: {
-          chainId: mainnet.id,
+          chain: mainnet,
           blockNumber: DEFAULT_BLOCK_NUMBER,
         },
         initialPage: 'easyBorrow',
@@ -308,7 +308,7 @@ test.describe('Deposit dialog', () => {
 
       const testContext = await setup(page, {
         blockchain: {
-          chainId: mainnet.id,
+          chain: mainnet,
           blockNumber: DEFAULT_BLOCK_NUMBER,
         },
         initialPage: 'myPortfolio',
@@ -353,7 +353,7 @@ test.describe('Deposit dialog', () => {
 
       const testContext = await setup(page, {
         blockchain: {
-          chainId: mainnet.id,
+          chain: mainnet,
           blockNumber: DEFAULT_BLOCK_NUMBER,
         },
         initialPage: 'myPortfolio',
@@ -392,7 +392,7 @@ test.describe('Deposit dialog', () => {
     test('retains some native asset when depositing max', async ({ page }) => {
       const testContext = await setup(page, {
         blockchain: {
-          chainId: mainnet.id,
+          chain: mainnet,
           blockNumber: DEFAULT_BLOCK_NUMBER,
         },
         initialPage: 'myPortfolio',

--- a/packages/app/src/features/dialogs/e-mode/EModeDialog.test-e2e.ts
+++ b/packages/app/src/features/dialogs/e-mode/EModeDialog.test-e2e.ts
@@ -17,7 +17,7 @@ test.describe('E-Mode dialog', () => {
     test.beforeEach(async ({ page }) => {
       const testContext = await setup(page, {
         blockchain: {
-          chainId: mainnet.id,
+          chain: mainnet,
           blockNumber: DEFAULT_BLOCK_NUMBER,
         },
         initialPage: 'easyBorrow',
@@ -150,7 +150,7 @@ test.describe('E-Mode dialog', () => {
     test.beforeEach(async ({ page }) => {
       const testContext = await setup(page, {
         blockchain: {
-          chainId: mainnet.id,
+          chain: mainnet,
           blockNumber: DEFAULT_BLOCK_NUMBER,
         },
         initialPage: 'easyBorrow',
@@ -262,7 +262,7 @@ test.describe('E-Mode dialog', () => {
     test.beforeEach(async ({ page }) => {
       const testContext = await setup(page, {
         blockchain: {
-          chainId: mainnet.id,
+          chain: mainnet,
           blockNumber: DEFAULT_BLOCK_NUMBER,
         },
         initialPage: 'easyBorrow',
@@ -357,7 +357,7 @@ test.describe('E-Mode dialog', () => {
     test.beforeEach(async ({ page }) => {
       const testContext = await setup(page, {
         blockchain: {
-          chainId: mainnet.id,
+          chain: mainnet,
           blockNumber: DEFAULT_BLOCK_NUMBER,
         },
         initialPage: 'easyBorrow',
@@ -460,7 +460,7 @@ test.describe('E-Mode dialog', () => {
       test.beforeEach(async ({ page }) => {
         const testContext = await setup(page, {
           blockchain: {
-            chainId: mainnet.id,
+            chain: mainnet,
             blockNumber: DEFAULT_BLOCK_NUMBER,
           },
           initialPage: 'easyBorrow',
@@ -531,7 +531,7 @@ test.describe('E-Mode dialog', () => {
       test.beforeEach(async ({ page }) => {
         const testContext = await setup(page, {
           blockchain: {
-            chainId: mainnet.id,
+            chain: mainnet,
             blockNumber: DEFAULT_BLOCK_NUMBER,
           },
           initialPage: 'easyBorrow',

--- a/packages/app/src/features/dialogs/repay/RepayDialog.test-e2e.ts
+++ b/packages/app/src/features/dialogs/repay/RepayDialog.test-e2e.ts
@@ -33,7 +33,7 @@ test.describe('Repay dialog', () => {
       testContext = await setup(page, {
         blockchain: {
           blockNumber: DEFAULT_BLOCK_NUMBER,
-          chainId: mainnet.id,
+          chain: mainnet,
         },
         initialPage: 'easyBorrow',
         account: {
@@ -174,7 +174,7 @@ test.describe('Repay dialog', () => {
       testContext = await setup(page, {
         blockchain: {
           blockNumber: DEFAULT_BLOCK_NUMBER,
-          chainId: mainnet.id,
+          chain: mainnet,
         },
         initialPage: 'easyBorrow',
         account: {
@@ -316,7 +316,7 @@ test.describe('Repay dialog', () => {
       testContext = await setup(page, {
         blockchain: {
           blockNumber: DEFAULT_BLOCK_NUMBER,
-          chainId: mainnet.id,
+          chain: mainnet,
         },
         initialPage: 'easyBorrow',
         account: {
@@ -505,7 +505,7 @@ test.describe('Repay dialog', () => {
       testContext = await setup(page, {
         blockchain: {
           blockNumber: DEFAULT_BLOCK_NUMBER,
-          chainId: mainnet.id,
+          chain: mainnet,
         },
         initialPage: 'easyBorrow',
         account: {
@@ -573,7 +573,7 @@ test.describe('Repay dialog', () => {
       testContext = await setup(page, {
         blockchain: {
           blockNumber: DEFAULT_BLOCK_NUMBER,
-          chainId: mainnet.id,
+          chain: mainnet,
         },
         initialPage: 'easyBorrow',
         account: {

--- a/packages/app/src/features/dialogs/savings/common/e2e/SavingsDialog.PageObject.ts
+++ b/packages/app/src/features/dialogs/savings/common/e2e/SavingsDialog.PageObject.ts
@@ -1,7 +1,6 @@
 import { TestContext } from '@/test/e2e/setup'
 import { getBalance, getTokenBalance } from '@/test/e2e/utils'
 import { testIds } from '@/ui/utils/testIds'
-import { getUrlFromClient } from '@marsfoundation/common-testnets'
 import { Locator, expect } from '@playwright/test'
 import { Address } from 'viem'
 import { DialogPageObject, TxOverviewWithRoute } from '../../../common/Dialog.PageObject'
@@ -120,7 +119,7 @@ export class SavingsDialogPageObject extends DialogPageObject {
     expectedBalance: number
   }): Promise<void> {
     const currentBalance = await getBalance({
-      forkUrl: getUrlFromClient(this.testContext.testnetController.client),
+      client: this.testContext.testnetController.client,
       address: receiver,
     })
     expect(currentBalance.isEqualTo(expectedBalance)).toBe(true)
@@ -136,7 +135,7 @@ export class SavingsDialogPageObject extends DialogPageObject {
     expectedBalance: number
   }): Promise<void> {
     const currentTokenBalance = await getTokenBalance({
-      forkUrl: getUrlFromClient(this.testContext.testnetController.client),
+      client: this.testContext.testnetController.client,
       address: receiver,
       token,
     })

--- a/packages/app/src/features/dialogs/savings/deposit/e2e/General.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/deposit/e2e/General.test-e2e.ts
@@ -13,7 +13,7 @@ test.describe('Savings deposit dialog', () => {
     test.beforeEach(async ({ page }) => {
       const testContext = await setup(page, {
         blockchain: {
-          chainId: mainnet.id,
+          chain: mainnet,
           blockNumber: DEFAULT_BLOCK_NUMBER,
         },
         initialPage: 'savings',
@@ -81,7 +81,7 @@ test.describe('Savings deposit dialog', () => {
     test.beforeEach(async ({ page }) => {
       const testContext = await setup(page, {
         blockchain: {
-          chainId: gnosis.id,
+          chain: gnosis,
           blockNumber: GNOSIS_DEFAULT_BLOCK_NUMBER,
         },
         initialPage: 'savings',
@@ -112,7 +112,7 @@ test.describe('Savings deposit dialog', () => {
     test.beforeEach(async ({ page }) => {
       const testContext = await setup(page, {
         blockchain: {
-          chainId: base.id,
+          chain: base,
           blockNumber: BASE_DEFAULT_BLOCK_NUMBER,
         },
         initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/deposit/e2e/Validation.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/deposit/e2e/Validation.test-e2e.ts
@@ -14,7 +14,7 @@ test.describe('Validation', () => {
     test.beforeEach(async ({ page }) => {
       const testContext = await setup(page, {
         blockchain: {
-          chainId: mainnet.id,
+          chain: mainnet,
           blockNumber: DEFAULT_BLOCK_NUMBER,
         },
         initialPage: 'savings',
@@ -70,7 +70,7 @@ test.describe('Validation', () => {
   test('displays validation error for dirty input with 0 value', async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/deposit/e2e/base/DepositUSDC.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/deposit/e2e/base/DepositUSDC.test-e2e.ts
@@ -12,7 +12,7 @@ test.describe('Deposit USDC', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: base.id,
+        chain: base,
         blockNumber: BASE_DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/deposit/e2e/base/DepositUSDS.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/deposit/e2e/base/DepositUSDS.test-e2e.ts
@@ -12,7 +12,7 @@ test.describe('Deposit USDS', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: base.id,
+        chain: base,
         blockNumber: BASE_DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/deposit/e2e/gnosis/DepositXDAI.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/deposit/e2e/gnosis/DepositXDAI.test-e2e.ts
@@ -12,7 +12,7 @@ test.describe('Deposit XDAI on Gnosis', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: gnosis.id,
+        chain: gnosis,
         blockNumber: GNOSIS_DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/deposit/e2e/mainnet/DepositDAI.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/deposit/e2e/mainnet/DepositDAI.test-e2e.ts
@@ -13,7 +13,7 @@ test.describe('Deposit DAI', () => {
   test.beforeEach(async ({ page }) => {
     testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/deposit/e2e/mainnet/DepositUSDC.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/deposit/e2e/mainnet/DepositUSDC.test-e2e.ts
@@ -13,7 +13,7 @@ test.describe('Deposit USDC', () => {
   test.beforeEach(async ({ page }) => {
     testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/deposit/e2e/mainnet/DepositUSDS.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/deposit/e2e/mainnet/DepositUSDS.test-e2e.ts
@@ -13,7 +13,7 @@ test.describe('Deposit USDS', () => {
   test.beforeEach(async ({ page }) => {
     testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/migrate/downgrade/e2e/UsdsToDai.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/migrate/downgrade/e2e/UsdsToDai.test-e2e.ts
@@ -9,7 +9,7 @@ test.describe('Downgrade USDS to DAI', () => {
   test('downgrade to DAI is disabled when USDS balance is 0', async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',
@@ -27,7 +27,7 @@ test.describe('Downgrade USDS to DAI', () => {
   test('uses downgrade action', async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',
@@ -54,7 +54,7 @@ test.describe('Downgrade USDS to DAI', () => {
   test('displays transaction overview', async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',
@@ -90,7 +90,7 @@ test.describe('Downgrade USDS to DAI', () => {
   test('executes transaction', async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/migrate/upgrade/e2e/DaiToUsds.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/migrate/upgrade/e2e/DaiToUsds.test-e2e.ts
@@ -9,7 +9,7 @@ test.describe('Upgrade DAI to USDS', () => {
   test('does not show upgrade button when DAI balance is 0', async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',
@@ -30,7 +30,7 @@ test.describe('Upgrade DAI to USDS', () => {
   test('uses upgrade action', async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',
@@ -56,7 +56,7 @@ test.describe('Upgrade DAI to USDS', () => {
   test('displays transaction overview', async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',
@@ -89,7 +89,7 @@ test.describe('Upgrade DAI to USDS', () => {
   test('executes transaction', async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/migrate/upgrade/e2e/sDaiToSUsds.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/migrate/upgrade/e2e/sDaiToSUsds.test-e2e.ts
@@ -9,7 +9,7 @@ test.describe('Upgrade sDAI to sUSDS', () => {
   test('does not show upgrade banner when sDai balance is 0', async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',
@@ -30,7 +30,7 @@ test.describe('Upgrade sDAI to sUSDS', () => {
   test('uses upgrade action', async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',
@@ -56,7 +56,7 @@ test.describe('Upgrade sDAI to sUSDS', () => {
   test('displays transaction overview', async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',
@@ -95,7 +95,7 @@ test.describe('Upgrade sDAI to sUSDS', () => {
   test('executes transaction', async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/withdraw/e2e/base/General.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/withdraw/e2e/base/General.test-e2e.ts
@@ -9,7 +9,7 @@ test.describe('Without send mode', () => {
   test('can switch between tokens', async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: base.id,
+        chain: base,
         blockNumber: BASE_DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',
@@ -57,7 +57,7 @@ test.describe('With send mode', () => {
   test('can select only supported assets', async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: base.id,
+        chain: base,
         blockNumber: BASE_DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/withdraw/e2e/base/SendUSDC.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/withdraw/e2e/base/SendUSDC.test-e2e.ts
@@ -17,7 +17,7 @@ test.describe('Send USDC', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: base.id,
+        chain: base,
         blockNumber: BASE_DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/withdraw/e2e/base/SendUSDS.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/withdraw/e2e/base/SendUSDS.test-e2e.ts
@@ -16,7 +16,7 @@ test.describe('Send USDS', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: base.id,
+        chain: base,
         blockNumber: BASE_DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/withdraw/e2e/base/WithdrawMaxUSDC.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/withdraw/e2e/base/WithdrawMaxUSDC.test-e2e.ts
@@ -12,7 +12,7 @@ test.describe('Withdraw Max USDC', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: base.id,
+        chain: base,
         blockNumber: BASE_DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/withdraw/e2e/base/WithdrawMaxUSDS.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/withdraw/e2e/base/WithdrawMaxUSDS.test-e2e.ts
@@ -12,7 +12,7 @@ test.describe('Withdraw Max USDS', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: base.id,
+        chain: base,
         blockNumber: BASE_DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/withdraw/e2e/base/WithdrawUSDC.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/withdraw/e2e/base/WithdrawUSDC.test-e2e.ts
@@ -12,7 +12,7 @@ test.describe('Withdraw USDC', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: base.id,
+        chain: base,
         blockNumber: BASE_DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/withdraw/e2e/base/WithdrawUSDS.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/withdraw/e2e/base/WithdrawUSDS.test-e2e.ts
@@ -12,7 +12,7 @@ test.describe('Withdraw USDS', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: base.id,
+        chain: base,
         blockNumber: BASE_DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/withdraw/e2e/gnosis/General.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/withdraw/e2e/gnosis/General.test-e2e.ts
@@ -9,7 +9,7 @@ test.describe('With send mode', () => {
   test('can select only supported assets', async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: gnosis.id,
+        chain: gnosis,
         blockNumber: GNOSIS_DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/withdraw/e2e/gnosis/SendXDAI.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/withdraw/e2e/gnosis/SendXDAI.test-e2e.ts
@@ -15,7 +15,7 @@ test.describe('Send XDAI on Gnosis', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: gnosis.id,
+        chain: gnosis,
         blockNumber: GNOSIS_DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/withdraw/e2e/gnosis/WithdrawMaxXDAI.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/withdraw/e2e/gnosis/WithdrawMaxXDAI.test-e2e.ts
@@ -12,7 +12,7 @@ test.describe('Withdraw max XDAI on Gnosis', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: gnosis.id,
+        chain: gnosis,
         blockNumber: GNOSIS_DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/withdraw/e2e/gnosis/WithdrawXDAI.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/withdraw/e2e/gnosis/WithdrawXDAI.test-e2e.ts
@@ -12,7 +12,7 @@ test.describe('Withdraw XDAI on Gnosis', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: gnosis.id,
+        chain: gnosis,
         blockNumber: GNOSIS_DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/withdraw/e2e/mainnet/General.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/withdraw/e2e/mainnet/General.test-e2e.ts
@@ -12,7 +12,7 @@ test.describe('Without send mode', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',
@@ -69,7 +69,7 @@ test.describe('With send mode', () => {
   test('can select only supported assets', async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/withdraw/e2e/mainnet/SendDAI.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/withdraw/e2e/mainnet/SendDAI.test-e2e.ts
@@ -16,7 +16,7 @@ test.describe('Send DAI on Mainnet', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/withdraw/e2e/mainnet/SendDAIValidation.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/withdraw/e2e/mainnet/SendDAIValidation.test-e2e.ts
@@ -17,7 +17,7 @@ test.describe('Asset input validation', () => {
     test.beforeEach(async ({ page }) => {
       const testContext = await setup(page, {
         blockchain: {
-          chainId: mainnet.id,
+          chain: mainnet,
           blockNumber: DEFAULT_BLOCK_NUMBER,
         },
         initialPage: 'savings',
@@ -69,7 +69,7 @@ test.describe('Asset input validation', () => {
   test('displays validation error for dirty input with 0 value', async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',
@@ -102,7 +102,7 @@ test.describe('Receiver input validation', () => {
     test.beforeEach(async ({ page }) => {
       const testContext = await setup(page, {
         blockchain: {
-          chainId: mainnet.id,
+          chain: mainnet,
           blockNumber: DEFAULT_BLOCK_NUMBER,
         },
         initialPage: 'savings',
@@ -179,7 +179,7 @@ test.describe('Receiver input validation', () => {
   test('displays warning when receiver is smart contract address', async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',
@@ -209,7 +209,7 @@ test.describe('Form validation', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/withdraw/e2e/mainnet/SendUSDC.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/withdraw/e2e/mainnet/SendUSDC.test-e2e.ts
@@ -16,7 +16,7 @@ test.describe('Send USDC (withdrawing from sUSDS)', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',
@@ -104,7 +104,7 @@ test.describe('Send USDC (withdrawing from sDAI)', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/withdraw/e2e/mainnet/SendUSDS.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/withdraw/e2e/mainnet/SendUSDS.test-e2e.ts
@@ -16,7 +16,7 @@ test.describe('Send USDS (withdrawing from sUSDS)', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',
@@ -98,7 +98,7 @@ test.describe('Send USDS (withdrawing from sDAI)', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/withdraw/e2e/mainnet/WithdrawDAI.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/withdraw/e2e/mainnet/WithdrawDAI.test-e2e.ts
@@ -13,7 +13,7 @@ test.describe('Withdraw DAI on Mainnet', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',
@@ -75,7 +75,7 @@ test.describe('Validation', () => {
     test.beforeEach(async ({ page }) => {
       const testContext = await setup(page, {
         blockchain: {
-          chainId: mainnet.id,
+          chain: mainnet,
           blockNumber: DEFAULT_BLOCK_NUMBER,
         },
         initialPage: 'savings',
@@ -126,7 +126,7 @@ test.describe('Validation', () => {
   test('displays validation error for dirty input with 0 value', async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/withdraw/e2e/mainnet/WithdrawMaxDAI.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/withdraw/e2e/mainnet/WithdrawMaxDAI.test-e2e.ts
@@ -12,7 +12,7 @@ test.describe('Withdraw max DAI on Mainnet', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/withdraw/e2e/mainnet/WithdrawMaxUSDC.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/withdraw/e2e/mainnet/WithdrawMaxUSDC.test-e2e.ts
@@ -12,7 +12,7 @@ test.describe('Withdraw USDC from sUSDS', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',
@@ -87,7 +87,7 @@ test.describe('Withdraw USDC from sDAI', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/withdraw/e2e/mainnet/WithdrawMaxUSDS.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/withdraw/e2e/mainnet/WithdrawMaxUSDS.test-e2e.ts
@@ -12,7 +12,7 @@ test.describe('Withdraw USDS from sUSDS', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',
@@ -81,7 +81,7 @@ test.describe('Withdraw USDS from sDAI', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/withdraw/e2e/mainnet/WithdrawUSDC.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/withdraw/e2e/mainnet/WithdrawUSDC.test-e2e.ts
@@ -12,7 +12,7 @@ test.describe('Withdraw USDC from sUSDS', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',
@@ -87,7 +87,7 @@ test.describe('Withdraw USDC from sDAI', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/savings/withdraw/e2e/mainnet/WithdrawUSDS.test-e2e.ts
+++ b/packages/app/src/features/dialogs/savings/withdraw/e2e/mainnet/WithdrawUSDS.test-e2e.ts
@@ -12,7 +12,7 @@ test.describe('Withdraw USDS from sUSDS', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',
@@ -81,7 +81,7 @@ test.describe('Withdraw USDS from sDAI', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'savings',

--- a/packages/app/src/features/dialogs/withdraw/WithdrawDialog.test-e2e.ts
+++ b/packages/app/src/features/dialogs/withdraw/WithdrawDialog.test-e2e.ts
@@ -33,7 +33,7 @@ test.describe('Withdraw dialog', () => {
       const testContext = await setup(page, {
         blockchain: {
           blockNumber: DEFAULT_BLOCK_NUMBER,
-          chainId: mainnet.id,
+          chain: mainnet,
         },
         initialPage: 'easyBorrow',
         account: {
@@ -117,7 +117,7 @@ test.describe('Withdraw dialog', () => {
       const testContext = await setup(page, {
         blockchain: {
           blockNumber: DEFAULT_BLOCK_NUMBER,
-          chainId: mainnet.id,
+          chain: mainnet,
         },
         initialPage: 'easyBorrow',
         account: {
@@ -174,7 +174,7 @@ test.describe('Withdraw dialog', () => {
       const testContext = await setup(page, {
         blockchain: {
           blockNumber: DEFAULT_BLOCK_NUMBER,
-          chainId: mainnet.id,
+          chain: mainnet,
         },
         initialPage: 'easyBorrow',
         account: {
@@ -251,7 +251,7 @@ test.describe('Withdraw dialog', () => {
       const testContext = await setup(page, {
         blockchain: {
           blockNumber: DEFAULT_BLOCK_NUMBER,
-          chainId: mainnet.id,
+          chain: mainnet,
         },
         initialPage: 'easyBorrow',
         account: {
@@ -356,7 +356,7 @@ test.describe('Withdraw dialog', () => {
       testContext = await setup(page, {
         blockchain: {
           blockNumber: DEFAULT_BLOCK_NUMBER,
-          chainId: mainnet.id,
+          chain: mainnet,
         },
         initialPage: 'easyBorrow',
         account: {
@@ -448,7 +448,7 @@ test.describe('Withdraw dialog', () => {
       testContext = await setup(page, {
         blockchain: {
           blockNumber: DEFAULT_BLOCK_NUMBER,
-          chainId: mainnet.id,
+          chain: mainnet,
         },
         initialPage: 'myPortfolio',
         account: {
@@ -614,7 +614,7 @@ test.describe('Withdraw with actions batched', () => {
   test('can withdraw native asset', async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'easyBorrow',

--- a/packages/app/src/features/farm-details/FarmDetails.PageObject.ts
+++ b/packages/app/src/features/farm-details/FarmDetails.PageObject.ts
@@ -2,7 +2,6 @@ import { BasePageObject } from '@/test/e2e/BasePageObject'
 import { AssetsInTests, TOKENS_ON_FORK } from '@/test/e2e/constants'
 import { getTokenBalance } from '@/test/e2e/utils'
 import { testIds } from '@/ui/utils/testIds'
-import { getUrlFromClient } from '@marsfoundation/common-testnets'
 import { NormalizedUnitNumber } from '@marsfoundation/common-universal'
 import { Locator, expect } from '@playwright/test'
 import { Address } from 'viem'
@@ -66,8 +65,8 @@ export class FarmDetailsPageObject extends BasePageObject {
     const chainId = await this.testContext.testnetController.client.getChainId()
     const token: { address: Address; decimals: number } = (TOKENS_ON_FORK as any)[chainId][symbol]
     const actualBalance = await getTokenBalance({
+      client: this.testContext.testnetController.client,
       address,
-      forkUrl: getUrlFromClient(this.testContext.testnetController.client),
       token,
     })
     expect(balance.eq(actualBalance)).toBe(true)

--- a/packages/app/src/features/farm-details/dialogs/claim/e2e/mainnet/ClaimSKY.test-e2e.ts
+++ b/packages/app/src/features/farm-details/dialogs/claim/e2e/mainnet/ClaimSKY.test-e2e.ts
@@ -17,7 +17,7 @@ test.describe('Claim SKY rewards', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'farmDetails',

--- a/packages/app/src/features/farm-details/dialogs/stake/e2e/mainnet/StakeDAI.test-e2e.ts
+++ b/packages/app/src/features/farm-details/dialogs/stake/e2e/mainnet/StakeDAI.test-e2e.ts
@@ -14,7 +14,7 @@ test.describe('Stake DAI to SKY farm', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: DEFAULT_BLOCK_NUMBER,
-        chainId: mainnet.id,
+        chain: mainnet,
       },
       initialPage: 'farmDetails',
       initialPageParams: {

--- a/packages/app/src/features/farm-details/dialogs/stake/e2e/mainnet/StakeSDAI.test-e2e.ts
+++ b/packages/app/src/features/farm-details/dialogs/stake/e2e/mainnet/StakeSDAI.test-e2e.ts
@@ -13,7 +13,7 @@ test.describe('Stake sDAI to SKY farm', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'farmDetails',

--- a/packages/app/src/features/farm-details/dialogs/stake/e2e/mainnet/StakeSUSDS.test-e2e.ts
+++ b/packages/app/src/features/farm-details/dialogs/stake/e2e/mainnet/StakeSUSDS.test-e2e.ts
@@ -16,7 +16,7 @@ test.describe('Stake sUSDS to SKY farm', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: DEFAULT_BLOCK_NUMBER,
-        chainId: mainnet.id,
+        chain: mainnet,
       },
       initialPage: 'savings',
       account: {
@@ -105,7 +105,7 @@ test.describe('Stake sUSDS to SKY farm with actions batched', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: DEFAULT_BLOCK_NUMBER,
-        chainId: mainnet.id,
+        chain: mainnet,
       },
       initialPage: 'savings',
       account: {

--- a/packages/app/src/features/farm-details/dialogs/stake/e2e/mainnet/StakeUSDC.test-e2e.ts
+++ b/packages/app/src/features/farm-details/dialogs/stake/e2e/mainnet/StakeUSDC.test-e2e.ts
@@ -14,7 +14,7 @@ test.describe('Stake USDC to SKY farm', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: DEFAULT_BLOCK_NUMBER,
-        chainId: mainnet.id,
+        chain: mainnet,
       },
       initialPage: 'farmDetails',
       initialPageParams: {

--- a/packages/app/src/features/farm-details/dialogs/stake/e2e/mainnet/StakeUSDS.test-e2e.ts
+++ b/packages/app/src/features/farm-details/dialogs/stake/e2e/mainnet/StakeUSDS.test-e2e.ts
@@ -15,7 +15,7 @@ test.describe('Stake USDS to SKY farm', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: DEFAULT_BLOCK_NUMBER,
-        chainId: mainnet.id,
+        chain: mainnet,
       },
       initialPage: 'farmDetails',
       initialPageParams: {
@@ -94,7 +94,7 @@ test.describe('Stake USDS to CLE farm', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: DEFAULT_BLOCK_NUMBER,
-        chainId: mainnet.id,
+        chain: mainnet,
       },
       initialPage: 'farmDetails',
       initialPageParams: {

--- a/packages/app/src/features/farm-details/dialogs/unstake/e2e/mainnet/UnstakeDAI.test-e2e.ts
+++ b/packages/app/src/features/farm-details/dialogs/unstake/e2e/mainnet/UnstakeDAI.test-e2e.ts
@@ -16,7 +16,7 @@ test.describe('Unstake DAI from SKY farm', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: DEFAULT_BLOCK_NUMBER,
-        chainId: mainnet.id,
+        chain: mainnet,
       },
       initialPage: 'farmDetails',
       initialPageParams: {

--- a/packages/app/src/features/farm-details/dialogs/unstake/e2e/mainnet/UnstakeUSDC.test-e2e.ts
+++ b/packages/app/src/features/farm-details/dialogs/unstake/e2e/mainnet/UnstakeUSDC.test-e2e.ts
@@ -16,7 +16,7 @@ test.describe('Unstake USDC from SKY farm', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: DEFAULT_BLOCK_NUMBER,
-        chainId: mainnet.id,
+        chain: mainnet,
       },
       initialPage: 'farmDetails',
       initialPageParams: {

--- a/packages/app/src/features/farm-details/dialogs/unstake/e2e/mainnet/UnstakeUSDS.test-e2e.ts
+++ b/packages/app/src/features/farm-details/dialogs/unstake/e2e/mainnet/UnstakeUSDS.test-e2e.ts
@@ -17,7 +17,7 @@ test.describe('Unstake USDS from SKY farm', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: DEFAULT_BLOCK_NUMBER,
-        chainId: mainnet.id,
+        chain: mainnet,
       },
       initialPage: 'farmDetails',
       initialPageParams: {
@@ -111,7 +111,7 @@ test.describe('Unstake USDS from CLE farm', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: DEFAULT_BLOCK_NUMBER,
-        chainId: mainnet.id,
+        chain: mainnet,
       },
       initialPage: 'farmDetails',
       initialPageParams: {

--- a/packages/app/src/features/farm-details/dialogs/unstake/e2e/mainnet/WithdrawMaxDai.test-e2e.ts
+++ b/packages/app/src/features/farm-details/dialogs/unstake/e2e/mainnet/WithdrawMaxDai.test-e2e.ts
@@ -17,7 +17,7 @@ test.describe('Withdraw max DAI from SKY farm', () => {
 
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
-      blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+      blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
       initialPage: 'farmDetails',
       initialPageParams: {
         chainId: mainnet.id.toString(),

--- a/packages/app/src/features/farm-details/dialogs/unstake/e2e/mainnet/WithdrawMaxUSDC.test-e2e.ts
+++ b/packages/app/src/features/farm-details/dialogs/unstake/e2e/mainnet/WithdrawMaxUSDC.test-e2e.ts
@@ -17,7 +17,7 @@ test.describe('Withdraw max USDC from SKY farm', () => {
 
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
-      blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+      blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
       initialPage: 'farmDetails',
       initialPageParams: {
         chainId: mainnet.id.toString(),

--- a/packages/app/src/features/farm-details/dialogs/unstake/e2e/mainnet/WithdrawMaxUSDS.test-e2e.ts
+++ b/packages/app/src/features/farm-details/dialogs/unstake/e2e/mainnet/WithdrawMaxUSDS.test-e2e.ts
@@ -20,7 +20,7 @@ test.describe('Withdraw max USDS from SKY farm', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: DEFAULT_BLOCK_NUMBER,
-        chainId: mainnet.id,
+        chain: mainnet,
       },
       initialPage: 'farmDetails',
       initialPageParams: {
@@ -173,7 +173,7 @@ test.describe('Withdraw max USDS from CLE farm', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: DEFAULT_BLOCK_NUMBER,
-        chainId: mainnet.id,
+        chain: mainnet,
       },
       initialPage: 'farmDetails',
       initialPageParams: {

--- a/packages/app/src/features/topbar/Topbar.test-e2e.ts
+++ b/packages/app/src/features/topbar/Topbar.test-e2e.ts
@@ -10,7 +10,7 @@ test.describe('Topbar', () => {
   test.describe('Airdrop counter', () => {
     test('Disconnected', async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
         initialPage: 'easyBorrow',
         account: {
           type: 'not-connected',
@@ -25,7 +25,7 @@ test.describe('Topbar', () => {
 
     test('Connected', async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
         initialPage: 'easyBorrow',
         account: {
           type: 'connected-random',
@@ -42,7 +42,7 @@ test.describe('Topbar', () => {
 
     test('Api error', async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
         initialPage: 'easyBorrow',
         account: {
           type: 'connected-random',
@@ -57,7 +57,7 @@ test.describe('Topbar', () => {
 
     test('Wallet with no airdrop', async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
         initialPage: 'easyBorrow',
         account: {
           type: 'connected-random',
@@ -78,7 +78,7 @@ test.describe('Topbar', () => {
       const testContext = await setup(page, {
         blockchain: {
           blockNumber: DEFAULT_BLOCK_NUMBER,
-          chainId: mainnet.id,
+          chain: mainnet,
         },
         initialPage: 'easyBorrow',
         account: {
@@ -95,7 +95,7 @@ test.describe('Topbar', () => {
       const testContext = await setup(page, {
         blockchain: {
           blockNumber: DEFAULT_BLOCK_NUMBER,
-          chainId: mainnet.id,
+          chain: mainnet,
         },
         initialPage: 'easyBorrow',
         account: {
@@ -120,7 +120,7 @@ test.describe('Topbar', () => {
       const testContext = await setup(page, {
         blockchain: {
           blockNumber: DEFAULT_BLOCK_NUMBER,
-          chainId: mainnet.id,
+          chain: mainnet,
         },
         initialPage: 'myPortfolio',
         account: {
@@ -139,7 +139,7 @@ test.describe('Topbar', () => {
   test.describe('Malformed localStorage', () => {
     test('Sandbox info in wagmi.store but not in zustand-app-store', async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
         initialPage: 'easyBorrow',
         account: {
           type: 'not-connected',

--- a/packages/app/src/pages/Borrow.test-e2e.ts
+++ b/packages/app/src/pages/Borrow.test-e2e.ts
@@ -29,7 +29,7 @@ test.describe('Borrow page', () => {
     test.beforeEach(async ({ page }) => {
       testContext = await setup(page, {
         blockchain: {
-          chainId: mainnet.id,
+          chain: mainnet,
           blockNumber: DEFAULT_BLOCK_NUMBER,
         },
         initialPage: 'easyBorrow',
@@ -115,7 +115,7 @@ test.describe('Borrow page', () => {
     test.beforeEach(async ({ page }) => {
       testContext = await setup(page, {
         blockchain: {
-          chainId: mainnet.id,
+          chain: mainnet,
           blockNumber: DEFAULT_BLOCK_NUMBER,
         },
         initialPage: 'easyBorrow',
@@ -268,7 +268,7 @@ test.describe('Borrow page', () => {
     test.beforeEach(async ({ page }) => {
       testContext = await setup(page, {
         blockchain: {
-          chainId: mainnet.id,
+          chain: mainnet,
           blockNumber: DEFAULT_BLOCK_NUMBER,
         },
         initialPage: 'easyBorrow',
@@ -330,7 +330,7 @@ test.describe('Borrow page', () => {
   test('borrows usds', async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'easyBorrow',
@@ -388,7 +388,7 @@ test.describe('Borrow page', () => {
     test.beforeEach(async ({ page }) => {
       const testContext = await setup(page, {
         blockchain: {
-          chainId: mainnet.id,
+          chain: mainnet,
           blockNumber: DEFAULT_BLOCK_NUMBER,
         },
         initialPage: 'easyBorrow',
@@ -418,7 +418,7 @@ test.describe('Borrow page', () => {
     test.beforeEach(async ({ page }) => {
       const testContext = await setup(page, {
         blockchain: {
-          chainId: mainnet.id,
+          chain: mainnet,
           blockNumber: DEFAULT_BLOCK_NUMBER,
         },
         initialPage: 'easyBorrow',
@@ -491,7 +491,7 @@ test.describe('Borrow page', () => {
     test.beforeEach(async ({ page }) => {
       testContext = await setup(page, {
         blockchain: {
-          chainId: mainnet.id,
+          chain: mainnet,
           blockNumber: DEFAULT_BLOCK_NUMBER,
         },
         initialPage: 'easyBorrow',
@@ -533,7 +533,7 @@ test.describe('Borrow page', () => {
       test.beforeEach(async ({ page }) => {
         const testContext = await setup(page, {
           blockchain: {
-            chainId: mainnet.id,
+            chain: mainnet,
             blockNumber: DEFAULT_BLOCK_NUMBER,
           },
           initialPage: 'easyBorrow',
@@ -565,7 +565,7 @@ test.describe('Borrow page', () => {
     test('hf above danger zone threshold; risk warning is not shown', async ({ page }) => {
       const testContext = await setup(page, {
         blockchain: {
-          chainId: mainnet.id,
+          chain: mainnet,
           blockNumber: DEFAULT_BLOCK_NUMBER,
         },
         initialPage: 'easyBorrow',
@@ -588,7 +588,7 @@ test.describe('Borrow page', () => {
     test('can borrow DAI for ETH and cbBTC', async ({ page }) => {
       const testContext = await setup(page, {
         blockchain: {
-          chainId: mainnet.id,
+          chain: mainnet,
           blockNumber: DEFAULT_BLOCK_NUMBER,
         },
         initialPage: 'easyBorrow',
@@ -623,7 +623,7 @@ test.describe('Borrow page', () => {
     test('can borrow USDS for wstETH', async ({ page }) => {
       const testContext = await setup(page, {
         blockchain: {
-          chainId: mainnet.id,
+          chain: mainnet,
           blockNumber: DEFAULT_BLOCK_NUMBER,
         },
         initialPage: 'easyBorrow',

--- a/packages/app/src/pages/Farms.test-e2e.ts
+++ b/packages/app/src/pages/Farms.test-e2e.ts
@@ -12,7 +12,7 @@ test.describe('Farms', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: DEFAULT_BLOCK_NUMBER,
-        chainId: mainnet.id,
+        chain: mainnet,
       },
       initialPage: 'farms',
       account: {

--- a/packages/app/src/pages/MarketDetails.test-e2e.ts
+++ b/packages/app/src/pages/MarketDetails.test-e2e.ts
@@ -17,7 +17,7 @@ test.describe('Market details Mainnet', () => {
   test.describe('Market overview', () => {
     test('DAI', async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
         initialPage: 'marketDetails',
         initialPageParams: { asset: DAI, chainId: mainnet.id.toString() },
         account: {
@@ -33,7 +33,7 @@ test.describe('Market details Mainnet', () => {
 
     test('WETH', async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
         initialPage: 'marketDetails',
         initialPageParams: { asset: WETH, chainId: mainnet.id.toString() },
         account: {
@@ -51,7 +51,7 @@ test.describe('Market details Mainnet', () => {
         const testContext = await setup(page, {
           blockchain: {
             blockNumber: DEFAULT_BLOCK_NUMBER,
-            chainId: mainnet.id,
+            chain: mainnet,
           },
           initialPage: 'marketDetails',
           initialPageParams: { asset: WBTC, chainId: mainnet.id.toString() },
@@ -68,7 +68,7 @@ test.describe('Market details Mainnet', () => {
         const testContext = await setup(page, {
           blockchain: {
             blockNumber: DEFAULT_BLOCK_NUMBER,
-            chainId: mainnet.id,
+            chain: mainnet,
           },
           initialPage: 'marketDetails',
           initialPageParams: { asset: WEETH, chainId: mainnet.id.toString() },
@@ -90,7 +90,7 @@ test.describe('Market details Mainnet', () => {
 
     test('guest state', async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
         initialPage: 'marketDetails',
         initialPageParams: { asset: DAI, chainId: mainnet.id.toString() },
         account: {
@@ -110,7 +110,7 @@ test.describe('Market details Mainnet', () => {
 
     test("can't deposit if not enough balance", async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
         initialPage: 'marketDetails',
         initialPageParams: { asset: WETH, chainId: mainnet.id.toString() },
         account: {
@@ -127,7 +127,7 @@ test.describe('Market details Mainnet', () => {
 
     test("can't lend if not enough balance", async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
         initialPage: 'marketDetails',
         initialPageParams: { asset: DAI, chainId: mainnet.id.toString() },
         account: {
@@ -144,7 +144,7 @@ test.describe('Market details Mainnet', () => {
 
     test("can't borrow if not enough balance", async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
         initialPage: 'marketDetails',
         initialPageParams: { asset: DAI, chainId: mainnet.id.toString() },
         account: {
@@ -162,7 +162,7 @@ test.describe('Market details Mainnet', () => {
 
     test('opens dialogs for DAI', async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
         initialPage: 'easyBorrow',
         account: {
           type: 'connected-random',
@@ -199,7 +199,7 @@ test.describe('Market details Mainnet', () => {
 
     test('opens dialogs for WETH', async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
         initialPage: 'easyBorrow',
         account: {
           type: 'connected-random',
@@ -231,7 +231,7 @@ test.describe('Market details Mainnet', () => {
     // @todo: this scenario is inaccurate, because user has only ETH - in future dialog should open on ETH tab
     test('opens dialogs for WETH when having only ETH', async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
         initialPage: 'easyBorrow',
         account: {
           type: 'connected-random',
@@ -264,7 +264,7 @@ test.describe('Market details Mainnet', () => {
 
     test('wallet displays sum of WETH and ETH', async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
         initialPage: 'marketDetails',
         initialPageParams: {
           asset: WETH,
@@ -289,7 +289,7 @@ test.describe('Market details Mainnet', () => {
   test.describe('Isolated assets', () => {
     test('Correctly displays debt ceiling', async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
         initialPage: 'marketDetails',
         initialPageParams: { asset: WEETH, chainId: mainnet.id.toString() },
         account: {
@@ -308,7 +308,7 @@ test.describe('Market details Mainnet', () => {
 
     test('displays 404 page for unknown chain', async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
         initialPage: 'marketDetails',
         initialPageParams: { asset: DAI, chainId: '12345' },
         account: {
@@ -322,7 +322,7 @@ test.describe('Market details Mainnet', () => {
 
     test('displays 404 page for unknown asset', async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
         initialPage: 'marketDetails',
         initialPageParams: { asset: NOT_A_RESERVE, chainId: mainnet.id.toString() },
         account: {
@@ -338,7 +338,7 @@ test.describe('Market details Mainnet', () => {
   test.describe('Cap automator', () => {
     test('WETH', async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
         initialPage: 'marketDetails',
         initialPageParams: { asset: WETH, chainId: mainnet.id.toString() },
         account: {
@@ -359,7 +359,7 @@ test.describe('Market details Mainnet', () => {
 
     test('USDC', async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
         initialPage: 'marketDetails',
         initialPageParams: { asset: USDC, chainId: mainnet.id.toString() },
         account: {
@@ -378,7 +378,7 @@ test.describe('Market details Mainnet', () => {
 
     test('WBTC', async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
         initialPage: 'marketDetails',
         initialPageParams: { asset: WBTC, chainId: mainnet.id.toString() },
         account: {
@@ -401,7 +401,7 @@ test.describe('Market details Mainnet', () => {
   test.describe('Oracles', () => {
     test('Fixed price', async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
         initialPage: 'marketDetails',
         initialPageParams: { asset: DAI, chainId: mainnet.id.toString() },
         account: {
@@ -421,7 +421,7 @@ test.describe('Market details Mainnet', () => {
     })
     test('Market price - not redundant', async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
         initialPage: 'marketDetails',
         initialPageParams: { asset: WBTC, chainId: mainnet.id.toString() },
         account: {
@@ -443,7 +443,7 @@ test.describe('Market details Mainnet', () => {
 
     test('Yielding fixed price - redundant', async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+        blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
         initialPage: 'marketDetails',
         initialPageParams: { asset: WEETH, chainId: mainnet.id.toString() },
         account: {
@@ -483,7 +483,7 @@ test.describe('Market details Gnosis', () => {
   test.describe('Cap automator', () => {
     test('WETH', async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: GNOSIS_DEFAULT_BLOCK_NUMBER, chainId: gnosis.id },
+        blockchain: { blockNumber: GNOSIS_DEFAULT_BLOCK_NUMBER, chain: gnosis },
         initialPage: 'marketDetails',
         initialPageParams: { asset: WETH, chainId: gnosis.id.toString() },
         account: {
@@ -502,7 +502,7 @@ test.describe('Market details Gnosis', () => {
 
     test('XDAI', async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: GNOSIS_DEFAULT_BLOCK_NUMBER, chainId: gnosis.id },
+        blockchain: { blockNumber: GNOSIS_DEFAULT_BLOCK_NUMBER, chain: gnosis },
         initialPage: 'marketDetails',
         initialPageParams: { asset: XDAI, chainId: gnosis.id.toString() },
         account: {
@@ -525,7 +525,7 @@ test.describe('Market details Gnosis', () => {
   test.describe('Oracles', () => {
     test('Fixed price', async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: GNOSIS_DEFAULT_BLOCK_NUMBER, chainId: gnosis.id },
+        blockchain: { blockNumber: GNOSIS_DEFAULT_BLOCK_NUMBER, chain: gnosis },
         initialPage: 'marketDetails',
         initialPageParams: { asset: XDAI, chainId: gnosis.id.toString() },
         account: {
@@ -546,7 +546,7 @@ test.describe('Market details Gnosis', () => {
 
     test('Underlying asset price', async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: GNOSIS_DEFAULT_BLOCK_NUMBER, chainId: gnosis.id },
+        blockchain: { blockNumber: GNOSIS_DEFAULT_BLOCK_NUMBER, chain: gnosis },
         initialPage: 'marketDetails',
         initialPageParams: { asset: EURe, chainId: gnosis.id.toString() },
         account: {
@@ -567,7 +567,7 @@ test.describe('Market details Gnosis', () => {
 
     test('Yielding fixed price - not redundant', async ({ page }) => {
       const testContext = await setup(page, {
-        blockchain: { blockNumber: GNOSIS_DEFAULT_BLOCK_NUMBER, chainId: gnosis.id },
+        blockchain: { blockNumber: GNOSIS_DEFAULT_BLOCK_NUMBER, chain: gnosis },
         initialPage: 'marketDetails',
         initialPageParams: { asset: sDAI, chainId: gnosis.id.toString() },
         account: {

--- a/packages/app/src/pages/Markets.test-e2e.ts
+++ b/packages/app/src/pages/Markets.test-e2e.ts
@@ -10,7 +10,7 @@ test.describe('Markets', () => {
   test.beforeEach(async ({ page }) => {
     const testContext = await setup(page, {
       blockchain: {
-        chainId: mainnet.id,
+        chain: mainnet,
         blockNumber: DEFAULT_BLOCK_NUMBER,
       },
       initialPage: 'markets',

--- a/packages/app/src/pages/MyPortfolio.test-e2e.ts
+++ b/packages/app/src/pages/MyPortfolio.test-e2e.ts
@@ -10,7 +10,7 @@ test.describe('MyPortfolio', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: DEFAULT_BLOCK_NUMBER,
-        chainId: mainnet.id,
+        chain: mainnet,
       },
       account: {
         type: 'not-connected',
@@ -26,7 +26,7 @@ test.describe('MyPortfolio', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: DEFAULT_BLOCK_NUMBER,
-        chainId: mainnet.id,
+        chain: mainnet,
       },
       initialPage: 'myPortfolio',
       account: {
@@ -49,7 +49,7 @@ test.describe('MyPortfolio', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: DEFAULT_BLOCK_NUMBER,
-        chainId: mainnet.id,
+        chain: mainnet,
       },
       initialPage: 'myPortfolio',
       account: {
@@ -77,7 +77,7 @@ test.describe('MyPortfolio', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: DEFAULT_BLOCK_NUMBER,
-        chainId: mainnet.id,
+        chain: mainnet,
       },
       initialPage: 'easyBorrow',
       account: {

--- a/packages/app/src/pages/Savings.test-e2e.ts
+++ b/packages/app/src/pages/Savings.test-e2e.ts
@@ -8,7 +8,7 @@ import { SavingsPageObject } from './Savings.PageObject'
 test.describe('Savings Mainnet', () => {
   test('guest state', async ({ page }) => {
     const testContext = await setup(page, {
-      blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+      blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
       initialPage: 'savings',
       account: {
         type: 'not-connected',
@@ -23,7 +23,7 @@ test.describe('Savings Mainnet', () => {
 
   test('calculates current value', async ({ page }) => {
     const testContext = await setup(page, {
-      blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+      blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
       initialPage: 'savings',
       account: {
         type: 'connected-random',
@@ -43,7 +43,7 @@ test.describe('Savings Mainnet', () => {
 
   test('calculates current projections', async ({ page }) => {
     const testContext = await setup(page, {
-      blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+      blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
       initialPage: 'savings',
       account: {
         type: 'connected-random',
@@ -61,7 +61,7 @@ test.describe('Savings Mainnet', () => {
 
   test('displays the total value of stablecoins in the wallet', async ({ page }) => {
     const testContext = await setup(page, {
-      blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chainId: mainnet.id },
+      blockchain: { blockNumber: DEFAULT_BLOCK_NUMBER, chain: mainnet },
       initialPage: 'savings',
       account: {
         type: 'connected-random',
@@ -81,7 +81,7 @@ test.describe('Savings Mainnet', () => {
 test.describe('Savings Gnosis', () => {
   test('guest state', async ({ page }) => {
     const testContext = await setup(page, {
-      blockchain: { blockNumber: GNOSIS_DEFAULT_BLOCK_NUMBER, chainId: gnosis.id },
+      blockchain: { blockNumber: GNOSIS_DEFAULT_BLOCK_NUMBER, chain: gnosis },
       initialPage: 'savings',
       account: {
         type: 'not-connected',
@@ -96,7 +96,7 @@ test.describe('Savings Gnosis', () => {
 
   test('calculates current value', async ({ page }) => {
     const testContext = await setup(page, {
-      blockchain: { blockNumber: GNOSIS_DEFAULT_BLOCK_NUMBER, chainId: gnosis.id },
+      blockchain: { blockNumber: GNOSIS_DEFAULT_BLOCK_NUMBER, chain: gnosis },
       initialPage: 'savings',
       account: {
         type: 'connected-random',
@@ -116,7 +116,7 @@ test.describe('Savings Gnosis', () => {
 
   test('calculates current projections', async ({ page }) => {
     const testContext = await setup(page, {
-      blockchain: { blockNumber: GNOSIS_DEFAULT_BLOCK_NUMBER, chainId: gnosis.id },
+      blockchain: { blockNumber: GNOSIS_DEFAULT_BLOCK_NUMBER, chain: gnosis },
       initialPage: 'savings',
       account: {
         type: 'connected-random',
@@ -134,7 +134,7 @@ test.describe('Savings Gnosis', () => {
 
   test('displays the total value of stablecoins in the wallet', async ({ page }) => {
     const testContext = await setup(page, {
-      blockchain: { blockNumber: GNOSIS_DEFAULT_BLOCK_NUMBER, chainId: gnosis.id },
+      blockchain: { blockNumber: GNOSIS_DEFAULT_BLOCK_NUMBER, chain: gnosis },
       initialPage: 'savings',
       account: {
         type: 'connected-random',
@@ -153,7 +153,7 @@ test.describe('Savings Gnosis', () => {
 test.describe('Savings Base', () => {
   test('guest state', async ({ page }) => {
     const testContext = await setup(page, {
-      blockchain: { blockNumber: BASE_DEFAULT_BLOCK_NUMBER, chainId: base.id },
+      blockchain: { blockNumber: BASE_DEFAULT_BLOCK_NUMBER, chain: base },
       initialPage: 'savings',
       account: {
         type: 'not-connected',
@@ -168,7 +168,7 @@ test.describe('Savings Base', () => {
 
   test('calculates current value', async ({ page }) => {
     const testContext = await setup(page, {
-      blockchain: { blockNumber: BASE_DEFAULT_BLOCK_NUMBER, chainId: base.id },
+      blockchain: { blockNumber: BASE_DEFAULT_BLOCK_NUMBER, chain: base },
       initialPage: 'savings',
       account: {
         type: 'connected-random',
@@ -188,7 +188,7 @@ test.describe('Savings Base', () => {
 
   test('calculates current projections', async ({ page }) => {
     const testContext = await setup(page, {
-      blockchain: { blockNumber: BASE_DEFAULT_BLOCK_NUMBER, chainId: base.id },
+      blockchain: { blockNumber: BASE_DEFAULT_BLOCK_NUMBER, chain: base },
       initialPage: 'savings',
       account: {
         type: 'connected-random',
@@ -206,7 +206,7 @@ test.describe('Savings Base', () => {
 
   test('displays the total value of stablecoins in the wallet', async ({ page }) => {
     const testContext = await setup(page, {
-      blockchain: { blockNumber: BASE_DEFAULT_BLOCK_NUMBER, chainId: base.id },
+      blockchain: { blockNumber: BASE_DEFAULT_BLOCK_NUMBER, chain: base },
       initialPage: 'savings',
       account: {
         type: 'connected-random',

--- a/packages/app/src/test/e2e/getTestnetContext.ts
+++ b/packages/app/src/test/e2e/getTestnetContext.ts
@@ -1,6 +1,7 @@
 import { randomHexId } from '@/utils/random'
 import { getEnv } from '@marsfoundation/common-nodejs/env'
 import { TenderlyTestnetFactory, TestnetClient } from '@marsfoundation/common-testnets'
+import { Chain } from 'viem'
 
 interface TestnetContext {
   client: TestnetClient
@@ -23,10 +24,10 @@ for (const eventType of ['exit', 'SIGINT', 'SIGUSR1', 'SIGUSR2', 'uncaughtExcept
 }
 
 export async function getTestnetContext({
-  chainId,
+  chain,
   blockNumber,
-}: { chainId: number; blockNumber: bigint }): Promise<TestnetContext> {
-  const key = `${chainId}-${blockNumber.toString()}`
+}: { chain: Chain; blockNumber: bigint }): Promise<TestnetContext> {
+  const key = `${chain.id}-${blockNumber.toString()}`
   if (testnetCache.has(key)) {
     return testnetCache.get(key)!
   }
@@ -42,8 +43,8 @@ export async function getTestnetContext({
   const { client, cleanup } = await factory.create({
     id: `test-e2e-${testnetId}`,
     displayName: `Spark E2E Testnet ${testnetId}`,
-    forkChainId: chainId,
-    originChainId: chainId,
+    originChain: chain,
+    forkChainId: chain.id,
     blockNumber,
   })
 

--- a/packages/app/src/test/e2e/setup.ts
+++ b/packages/app/src/test/e2e/setup.ts
@@ -1,6 +1,6 @@
 import { Path, paths } from '@/config/paths'
-import { TestnetClient, getUrlFromClient } from '@marsfoundation/common-testnets'
-import { assert, assertNever } from '@marsfoundation/common-universal'
+import { TestnetClient } from '@marsfoundation/common-testnets'
+import { assert, assertNever, extractUrlFromClient } from '@marsfoundation/common-universal'
 import { Page } from '@playwright/test'
 import { generatePath } from 'react-router-dom'
 import { Address, Chain, Hash, parseEther, parseUnits } from 'viem'
@@ -179,7 +179,7 @@ async function injectPageSetup({
   testnetClient: TestnetClient
   options: SetupOptions<any, any>
 }): Promise<AutoSimulationProgressController> {
-  const rpcUrl = getUrlFromClient(testnetClient)
+  const rpcUrl = extractUrlFromClient(testnetClient)
 
   if (options.skipInjectingNetwork === true) {
     // if explicitly disabled, do not inject network config abort all network requests to RPC providers

--- a/packages/app/src/test/e2e/setup.ts
+++ b/packages/app/src/test/e2e/setup.ts
@@ -3,7 +3,7 @@ import { TestnetClient, getUrlFromClient } from '@marsfoundation/common-testnets
 import { assert, assertNever } from '@marsfoundation/common-universal'
 import { Page } from '@playwright/test'
 import { generatePath } from 'react-router-dom'
-import { Address, Hash, parseEther, parseUnits } from 'viem'
+import { Address, Chain, Hash, parseEther, parseUnits } from 'viem'
 import { AssetsInTests, TOKENS_ON_FORK } from './constants'
 import { getTestnetContext } from './getTestnetContext'
 import { injectNetworkConfiguration, injectWalletConfiguration } from './injectSetup'
@@ -39,7 +39,7 @@ export type AccountOptions<T extends ConnectionType> = T extends 'not-connected'
     }
 
 export interface BlockchainOptions {
-  chainId: number
+  chain: Chain
   blockNumber: bigint
 }
 export interface SetupOptions<K extends Path, T extends ConnectionType> {
@@ -190,7 +190,7 @@ async function injectPageSetup({
     await injectNetworkConfiguration({
       page,
       rpcUrl,
-      chainId: options.blockchain.chainId,
+      chainId: options.blockchain.chain.id,
     })
   }
 

--- a/packages/app/src/ui/layouts/app-layout/components/PageNotSupportedWarning.test-e2e.ts
+++ b/packages/app/src/ui/layouts/app-layout/components/PageNotSupportedWarning.test-e2e.ts
@@ -10,7 +10,7 @@ test.describe('PageNotSupportedWarning', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: GNOSIS_DEFAULT_BLOCK_NUMBER,
-        chainId: gnosis.id,
+        chain: gnosis,
       },
       initialPage: 'farms',
       account: {
@@ -27,7 +27,7 @@ test.describe('PageNotSupportedWarning', () => {
     const testContext = await setup(page, {
       blockchain: {
         blockNumber: GNOSIS_DEFAULT_BLOCK_NUMBER,
-        chainId: gnosis.id,
+        chain: gnosis,
       },
       initialPage: 'savings',
       account: {

--- a/packages/common-nodejs/src/logger/LogFormatterPretty.ts
+++ b/packages/common-nodejs/src/logger/LogFormatterPretty.ts
@@ -30,7 +30,7 @@ interface Options {
 
 // @note: format methods are protected to allow easy construction of simpler formatters for non-standard environments
 export class LogFormatterPretty implements LogFormatter {
-  private readonly options: Options
+  protected readonly options: Options
 
   constructor(options?: Partial<Options>) {
     this.options = {

--- a/packages/common-testnets/src/TestnetClient.ts
+++ b/packages/common-testnets/src/TestnetClient.ts
@@ -1,4 +1,4 @@
-import { Hash, raise } from '@marsfoundation/common-universal'
+import { Hash } from '@marsfoundation/common-universal'
 import {
   Abi,
   Address,
@@ -32,8 +32,4 @@ export type TestnetClientHelperActions = {
   >(
     args: PartialBy<WriteContractParameters<abi, functionName, args, undefined>, 'chain'>, // avoids requiring chain parameter
   ) => Promise<WriteContractReturnType>
-}
-
-export function getUrlFromClient(client: TestnetClient): string {
-  return client.transport.type === 'http' ? client.transport.url : raise('Only http transport is supported')
 }

--- a/packages/common-testnets/src/TestnetFactory.test.ts
+++ b/packages/common-testnets/src/TestnetFactory.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'earl'
 import { after, before, describe, it } from 'mocha'
+import { base, mainnet } from 'viem/chains'
 import { TestnetClient } from './TestnetClient.js'
 import { createTestnetFactoriesForE2ETests } from './test-utils/index.js'
 
@@ -19,7 +20,7 @@ describe('TestnetFactory', () => {
         before(async () => {
           ;({ client: testnetClient, cleanup } = await factory.create({
             id: 'test',
-            originChainId: 1,
+            originChain: mainnet,
             forkChainId: expectedChainId,
             blockNumber,
           }))
@@ -76,7 +77,7 @@ describe('TestnetFactory', () => {
         before(async () => {
           ;({ client: testnetClient, cleanup } = await factory.create({
             id: 'test',
-            originChainId: 1,
+            originChain: mainnet,
             forkChainId: expectedChainId,
           }))
         })
@@ -87,6 +88,28 @@ describe('TestnetFactory', () => {
         it('can fetch block number', async () => {
           const currentBlockNumber = await testnetClient.getBlockNumber()
           expect(currentBlockNumber).toBeGreaterThan(21385842n)
+        })
+      })
+
+      describe('client', () => {
+        let testnetClient: TestnetClient
+        let cleanup: () => Promise<void>
+
+        before(async () => {
+          ;({ client: testnetClient, cleanup } = await factory.create({
+            id: 'test',
+            originChain: base,
+            forkChainId: expectedChainId,
+          }))
+        })
+        after(async () => {
+          await cleanup()
+        })
+
+        it('has correct chain id', async () => {
+          expect(await testnetClient.getChainId()).toEqual(expectedChainId)
+
+          expect(testnetClient.chain).toEqual({ ...base, id: expectedChainId })
         })
       })
     })

--- a/packages/common-testnets/src/TestnetFactory.ts
+++ b/packages/common-testnets/src/TestnetFactory.ts
@@ -1,3 +1,4 @@
+import { Chain } from 'viem'
 import { TestnetClient } from './TestnetClient.js'
 
 export interface TestnetCreateResult {
@@ -11,13 +12,13 @@ export interface TestnetCreateResult {
  */
 export interface TestnetFactory {
   create(network: CreateNetworkArgs): Promise<TestnetCreateResult>
-  createClientFromUrl(rpcUrl: string): TestnetClient
+  createClientFromUrl(rpcUrl: string, chain: Chain, forkChainId: number): TestnetClient
 }
 
 export interface CreateNetworkArgs {
   id: string
   displayName?: string
-  originChainId: number
+  originChain: Chain
   forkChainId: number
   blockNumber?: bigint
 }

--- a/packages/common-testnets/src/TestnetFactory.ts
+++ b/packages/common-testnets/src/TestnetFactory.ts
@@ -3,6 +3,7 @@ import { TestnetClient } from './TestnetClient.js'
 
 export interface TestnetCreateResult {
   client: TestnetClient
+  rpcUrl: string
   cleanup: () => Promise<void>
 }
 /**

--- a/packages/common-testnets/src/helpers/replaceSafeOwner.test.ts
+++ b/packages/common-testnets/src/helpers/replaceSafeOwner.test.ts
@@ -1,5 +1,6 @@
 import { CheckedAddress } from '@marsfoundation/common-universal'
 import { expect } from 'earl'
+import { mainnet } from 'viem/chains'
 import { TestnetClient } from '../TestnetClient.js'
 import { createTestnetFactoriesForE2ETests } from '../test-utils/index.js'
 import { getSafeOwners, replaceSafeOwner } from './replaceSafeOwner.js'
@@ -18,7 +19,7 @@ describe(replaceSafeOwner.name, () => {
       before(async () => {
         ;({ client: testnetClient, cleanup } = await factory.create({
           id: 'test',
-          originChainId: 1,
+          originChain: mainnet,
           forkChainId: 1,
           blockNumber: 21439277n,
         }))

--- a/packages/common-testnets/src/nodes/anvil/AnvilClient.ts
+++ b/packages/common-testnets/src/nodes/anvil/AnvilClient.ts
@@ -1,13 +1,12 @@
 import { assert, Hash } from '@marsfoundation/common-universal'
-import { http, Address, createTestClient, numberToHex, publicActions, walletActions } from 'viem'
+import { http, Address, Chain, createTestClient, numberToHex, publicActions, walletActions } from 'viem'
 import { dealActions } from 'viem-deal'
-import { mainnet } from 'viem/chains'
 import { TestnetClient } from '../../TestnetClient.js'
 import { extendWithTestnetHelpers } from '../extendWithTestnetHelpers.js'
 
-export function getAnvilClient(rpc: string): TestnetClient {
+export function getAnvilClient(rpc: string, chain: Chain, forkChainId: number): TestnetClient {
   return createTestClient({
-    chain: mainnet,
+    chain: { ...chain, id: forkChainId },
     mode: 'anvil',
     transport: http(rpc),
     cacheTime: 0, // do not cache block numbers

--- a/packages/common-testnets/src/nodes/anvil/AnvilTestnetFactory.ts
+++ b/packages/common-testnets/src/nodes/anvil/AnvilTestnetFactory.ts
@@ -37,11 +37,11 @@ export class AnvilTestnetFactory implements TestnetFactory {
 
     await anvil.start()
 
-    const url = `http://${anvil.host}:${anvil.port}`
+    const rpcUrl = `http://${anvil.host}:${anvil.port}`
 
     assert(anvil.status === 'listening', `Anvil failed to start: ${anvil.status}`)
 
-    const client = getAnvilClient(url, originChain, forkChainId)
+    const client = getAnvilClient(rpcUrl, originChain, forkChainId)
 
     const lastBlockTimestamp = (await client.getBlock()).timestamp
     await client.setNextBlockTimestamp(lastBlockTimestamp + 1n) // mineBlocks does not respect interval for the first block
@@ -49,6 +49,7 @@ export class AnvilTestnetFactory implements TestnetFactory {
 
     return {
       client,
+      rpcUrl,
       cleanup: async () => {
         await anvil.stop()
       },

--- a/packages/common-testnets/src/nodes/anvil/AnvilTestnetFactory.ts
+++ b/packages/common-testnets/src/nodes/anvil/AnvilTestnetFactory.ts
@@ -4,16 +4,16 @@ import { CreateNetworkArgs, TestnetCreateResult, TestnetFactory } from '../../Te
 
 import { createAnvil } from '@viem/anvil'
 import getPort from 'get-port'
-import { http, createPublicClient } from 'viem'
+import { http, Chain, createPublicClient } from 'viem'
 import { getAnvilClient } from './AnvilClient.js'
 
 export class AnvilTestnetFactory implements TestnetFactory {
   constructor(private readonly opts: { alchemyApiKey: string }) {}
 
   async create(args: CreateNetworkArgs): Promise<TestnetCreateResult> {
-    const { originChainId, forkChainId, blockNumber } = args
+    const { originChain, forkChainId, blockNumber } = args
 
-    const forkUrl = originChainIdToForkUrl(originChainId, this.opts.alchemyApiKey)
+    const forkUrl = originChainIdToForkUrl(originChain.id, this.opts.alchemyApiKey)
     // if forkChainId is specified, anvil requires blockNumber to be specified as well
     const forkBlockNumber = await (async () => {
       if (blockNumber) {
@@ -41,7 +41,7 @@ export class AnvilTestnetFactory implements TestnetFactory {
 
     assert(anvil.status === 'listening', `Anvil failed to start: ${anvil.status}`)
 
-    const client = getAnvilClient(url)
+    const client = getAnvilClient(url, originChain, forkChainId)
 
     const lastBlockTimestamp = (await client.getBlock()).timestamp
     await client.setNextBlockTimestamp(lastBlockTimestamp + 1n) // mineBlocks does not respect interval for the first block
@@ -55,8 +55,8 @@ export class AnvilTestnetFactory implements TestnetFactory {
     }
   }
 
-  createClientFromUrl(rpcUrl: string): TestnetClient {
-    return getAnvilClient(rpcUrl)
+  createClientFromUrl(rpcUrl: string, chain: Chain, forkChainId: number): TestnetClient {
+    return getAnvilClient(rpcUrl, chain, forkChainId)
   }
 }
 

--- a/packages/common-testnets/src/nodes/extendWithTestnetHelpers.test.ts
+++ b/packages/common-testnets/src/nodes/extendWithTestnetHelpers.test.ts
@@ -2,6 +2,7 @@ import { CheckedAddress } from '@marsfoundation/common-universal'
 import { expect } from 'earl'
 import { erc20Abi, parseEther } from 'viem'
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
+import { mainnet } from 'viem/chains'
 import { TestnetClient } from '../TestnetClient.js'
 import { createTestnetFactoriesForE2ETests } from '../test-utils/index.js'
 import { extendWithTestnetHelpers } from './extendWithTestnetHelpers.js'
@@ -17,7 +18,7 @@ describe(extendWithTestnetHelpers.name, () => {
       before(async () => {
         ;({ client: testnetClient, cleanup } = await factory.create({
           id: 'test',
-          originChainId: 1,
+          originChain: mainnet,
           forkChainId: 1,
           blockNumber: 21439277n,
         }))

--- a/packages/common-testnets/src/nodes/tenderly/TenderlyClient.ts
+++ b/packages/common-testnets/src/nodes/tenderly/TenderlyClient.ts
@@ -1,14 +1,13 @@
 import { Hash } from '@marsfoundation/common-universal'
-import { http, Address, createTestClient, numberToHex, publicActions, walletActions } from 'viem'
-import { mainnet } from 'viem/chains'
+import { http, Address, Chain, createTestClient, numberToHex, publicActions, walletActions } from 'viem'
 import { TestnetClient } from '../../TestnetClient.js'
 import { extendWithTestnetHelpers } from '../extendWithTestnetHelpers.js'
 
-export function getTenderlyClient(rpc: string): TestnetClient {
+export function getTenderlyClient(rpcUrl: string, chain: Chain, forkChainId: number): TestnetClient {
   return createTestClient({
-    chain: mainnet,
+    chain: { ...chain, id: forkChainId },
     mode: 'anvil',
-    transport: http(rpc),
+    transport: http(rpcUrl),
     cacheTime: 0, // do not cache block numbers
   })
     .extend((c) => {

--- a/packages/common-testnets/src/nodes/tenderly/TenderlyTestnetFactory.ts
+++ b/packages/common-testnets/src/nodes/tenderly/TenderlyTestnetFactory.ts
@@ -68,6 +68,7 @@ export class TenderlyTestnetFactory implements TestnetFactory {
 
     return {
       client,
+      rpcUrl: adminRpc.url,
       cleanup: () => Promise.resolve(),
     }
   }

--- a/packages/common-testnets/src/nodes/tenderly/TenderlyTestnetFactory.ts
+++ b/packages/common-testnets/src/nodes/tenderly/TenderlyTestnetFactory.ts
@@ -1,6 +1,6 @@
 import { assert, solidFetch } from '@marsfoundation/common-universal'
 import { v4 as uuidv4 } from 'uuid'
-import { numberToHex } from 'viem'
+import { Chain, numberToHex } from 'viem'
 import { z } from 'zod'
 import { TestnetClient } from '../../TestnetClient.js'
 import { CreateNetworkArgs, TestnetCreateResult, TestnetFactory } from '../../TestnetFactory.js'
@@ -10,7 +10,7 @@ export class TenderlyTestnetFactory implements TestnetFactory {
   constructor(private readonly opts: { apiKey: string; account: string; project: string }) {}
 
   async create(args: CreateNetworkArgs): Promise<TestnetCreateResult> {
-    const { id, displayName, originChainId, forkChainId, blockNumber } = args
+    const { id, displayName, originChain, forkChainId, blockNumber } = args
     const uniqueId = uuidv4()
 
     const response = await solidFetch(
@@ -25,7 +25,7 @@ export class TenderlyTestnetFactory implements TestnetFactory {
           slug: `${id}-${uniqueId}`,
           display_name: displayName,
           fork_config: {
-            network_id: originChainId,
+            network_id: originChain.id,
             block_number: Number(blockNumber) + 1,
           },
           virtual_network_config: {
@@ -51,7 +51,7 @@ export class TenderlyTestnetFactory implements TestnetFactory {
     const publicRpc = data.rpcs.find((rpc: any) => rpc.name === 'Public RPC')
     assert(adminRpc && publicRpc, 'Missing admin or public RPC')
 
-    const client = getTenderlyClient(adminRpc.url)
+    const client = this.createClientFromUrl(adminRpc.url, originChain, forkChainId)
     const legacyClient = client.extend((c) => ({
       async legacySetNextBlockTimestamp(timestamp: bigint) {
         await c.request({
@@ -72,8 +72,8 @@ export class TenderlyTestnetFactory implements TestnetFactory {
     }
   }
 
-  createClientFromUrl(rpcUrl: string): TestnetClient {
-    return getTenderlyClient(rpcUrl)
+  createClientFromUrl(rpcUrl: string, chain: Chain, forkChainId: number): TestnetClient {
+    return getTenderlyClient(rpcUrl, chain, forkChainId)
   }
 }
 

--- a/packages/common-universal/package.json
+++ b/packages/common-universal/package.json
@@ -27,9 +27,7 @@
       }
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "lint": "eslint src",
     "verify": "concurrently --names \"LINT,TEST,TYPECHECK,LINT-CUSTOM\" -c \"bgMagenta.bold,bgGreen.bold,bgBlue.bold,bgCyan.bold\" \"pnpm run lint\" \"pnpm run test --silent\" \"pnpm run typecheck\"",

--- a/packages/common-universal/package.json
+++ b/packages/common-universal/package.json
@@ -27,7 +27,9 @@
       }
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "lint": "eslint src",
     "verify": "concurrently --names \"LINT,TEST,TYPECHECK,LINT-CUSTOM\" -c \"bgMagenta.bold,bgGreen.bold,bgBlue.bold,bgCyan.bold\" \"pnpm run lint\" \"pnpm run test --silent\" \"pnpm run typecheck\"",
@@ -47,12 +49,14 @@
   "devDependencies": {
     "@sinonjs/fake-timers": "^13.0.5",
     "@types/mocha": "^10.0.10",
+    "@types/ms": "^2.1.0",
     "@types/sinonjs__fake-timers": "^8.1.5",
     "earl": "^1.3.0",
     "mocha": "^10.8.2"
   },
   "dependencies": {
     "fetch-retry": "^5.0.6",
+    "ms": "^2.1.3",
     "p-limit": "^6.1.0"
   }
 }

--- a/packages/common-universal/src/index.ts
+++ b/packages/common-universal/src/index.ts
@@ -26,3 +26,6 @@ export * from './data/unique.js'
 
 export * from './typeHelpers.js'
 export * from './networking/solidFetch.js'
+
+export * from './viem/types.js'
+export * from './viem/extractUrlFromClient.js'

--- a/packages/common-universal/src/types/UnixTime.test.ts
+++ b/packages/common-universal/src/types/UnixTime.test.ts
@@ -44,4 +44,17 @@ describe(UnixTime.name, () => {
       expect(time).toEqual(date)
     })
   })
+
+  describe(UnixTime.formatSpan.name, () => {
+    it('formats a span', () => {
+      expect(UnixTime.formatSpan(UnixTime.ONE_SECOND())).toEqual('1s')
+      expect(UnixTime.formatSpan(UnixTime.ONE_MINUTE())).toEqual('1m')
+      expect(UnixTime.formatSpan(UnixTime.ONE_DAY())).toEqual('1d')
+      expect(UnixTime.formatSpan(UnixTime.SEVEN_DAYS())).toEqual('7d')
+      expect(UnixTime.formatSpan(UnixTime.ONE_MONTH())).toEqual('30d')
+      expect(UnixTime.formatSpan(UnixTime.ONE_YEAR())).toEqual('365d')
+      expect(UnixTime.formatSpan(UnixTime(UnixTime.ONE_YEAR() - UnixTime.SEVEN_DAYS()))).toEqual('358d')
+      expect(UnixTime.formatSpan(UnixTime(UnixTime.ONE_YEAR() - UnixTime.ONE_HOUR()))).toEqual('365d')
+    })
+  })
 })

--- a/packages/common-universal/src/types/UnixTime.test.ts
+++ b/packages/common-universal/src/types/UnixTime.test.ts
@@ -51,7 +51,7 @@ describe(UnixTime.name, () => {
       expect(UnixTime.formatSpan(UnixTime.ONE_MINUTE())).toEqual('1m')
       expect(UnixTime.formatSpan(UnixTime.ONE_DAY())).toEqual('1d')
       expect(UnixTime.formatSpan(UnixTime.SEVEN_DAYS())).toEqual('7d')
-      expect(UnixTime.formatSpan(UnixTime.ONE_MONTH())).toEqual('30d')
+      expect(UnixTime.formatSpan(UnixTime.THIRTY_DAYS())).toEqual('30d')
       expect(UnixTime.formatSpan(UnixTime.ONE_YEAR())).toEqual('365d')
       expect(UnixTime.formatSpan(UnixTime(UnixTime.ONE_YEAR() - UnixTime.SEVEN_DAYS()))).toEqual('358d')
       expect(UnixTime.formatSpan(UnixTime(UnixTime.ONE_YEAR() - UnixTime.ONE_HOUR()))).toEqual('365d')

--- a/packages/common-universal/src/types/UnixTime.ts
+++ b/packages/common-universal/src/types/UnixTime.ts
@@ -1,6 +1,7 @@
 import { assert } from '../assert/assert.js'
 import { NumberLike, bigNumberify } from '../math/bigNumber.js'
 import { Opaque } from './Opaque.js'
+import ms from 'ms'
 
 /**
  * Represents a time span in seconds. i.e. 5.
@@ -65,6 +66,10 @@ UnixTime.toDate = (unixTime: UnixTime): Date => {
 
 UnixTime.toMilliseconds = (unixTime: UnixTime): number => {
   return Number(unixTime) * 1000
+}
+
+UnixTime.formatSpan = (span: UnixTime): string => {
+  return ms(UnixTime.toMilliseconds(span))
 }
 
 const YEAR_3000_TIMESTAMP = Math.floor(new Date('3000-01-01T00:00:00.000Z').getTime() / 1000)

--- a/packages/common-universal/src/types/UnixTime.ts
+++ b/packages/common-universal/src/types/UnixTime.ts
@@ -1,7 +1,7 @@
+import ms from 'ms'
 import { assert } from '../assert/assert.js'
 import { NumberLike, bigNumberify } from '../math/bigNumber.js'
 import { Opaque } from './Opaque.js'
-import ms from 'ms'
 
 /**
  * Represents a time span in seconds. i.e. 5.

--- a/packages/common-universal/src/viem/extractUrlFromClient.test.ts
+++ b/packages/common-universal/src/viem/extractUrlFromClient.test.ts
@@ -1,0 +1,17 @@
+import { expect } from 'earl'
+import { http, createPublicClient } from 'viem'
+import { mainnet } from 'viem/chains'
+import { extractUrlFromClient } from './extractUrlFromClient.js'
+
+describe(extractUrlFromClient.name, () => {
+  it('extracts url from public client', () => {
+    const sampleUrl = 'http://example.com'
+
+    const publicClient = createPublicClient({
+      chain: mainnet,
+      transport: http(sampleUrl),
+    })
+
+    expect(extractUrlFromClient(publicClient)).toEqual(sampleUrl)
+  })
+})

--- a/packages/common-universal/src/viem/extractUrlFromClient.ts
+++ b/packages/common-universal/src/viem/extractUrlFromClient.ts
@@ -1,0 +1,6 @@
+import { raise } from '../assert/assert.js'
+import { AnyViemClient } from './types.js'
+
+export function extractUrlFromClient(client: AnyViemClient): string {
+  return client.transport.type === 'http' ? client.transport.url : raise('Only http transport is supported')
+}

--- a/packages/common-universal/src/viem/types.ts
+++ b/packages/common-universal/src/viem/types.ts
@@ -1,0 +1,5 @@
+import { Client } from 'viem'
+
+// believe it or not but this seems to be the best way to create a type that accepts any client
+// otherwise running into issues with TestnetClient is very easy
+export type AnyViemClient = Client<any, any, any, any, any>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,6 +449,9 @@ importers:
       fetch-retry:
         specifier: ^5.0.6
         version: 5.0.6
+      ms:
+        specifier: ^2.1.3
+        version: 2.1.3
       p-limit:
         specifier: ^6.1.0
         version: 6.1.0
@@ -462,6 +465,9 @@ importers:
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
+      '@types/ms':
+        specifier: ^2.1.0
+        version: 2.1.0
       '@types/sinonjs__fake-timers':
         specifier: ^8.1.5
         version: 8.1.5
@@ -3432,6 +3438,9 @@ packages:
 
   '@types/ms@0.7.32':
     resolution: {integrity: sha512-xPSg0jm4mqgEkNhowKgZFBNtwoEwF6gJ4Dhww+GFpm3IgtNseHQZ5IqdNwnquZEoANxyDAKDRAdVo4Z72VvD/g==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node-forge@1.3.11':
     resolution: {integrity: sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==}
@@ -11760,6 +11769,8 @@ snapshots:
   '@types/mocha@10.0.10': {}
 
   '@types/ms@0.7.32': {}
+
+  '@types/ms@2.1.0': {}
 
   '@types/node-forge@1.3.11':
     dependencies:


### PR DESCRIPTION
- [x] Testnet package improvements:
	- [x] Correctly set chain on exported clients. Closes TS-112
	- [x] Return rpc url for the testnet alongside the client (to avoid extracting it forcefully)
	- [x] Move `extractUrlFromClient` to universal package
- [x] Universal package improvements
	- [x] Human readable format for UnixTime spans. Closes TS-113

A lot of code changes are related to simple argument changes in app e2e tests. Also I found some unused utils (`utils.ts` file) and deleted them.
